### PR TITLE
Document Makefile development steps + Make contributions easier with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+- init: make build
+  command: make test

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ if the result is okay.  Once you are satisifed run the tests again with
 $ INSTA_UPDATE=1 cargo test
 ```
 
+## Contributing
+
+To build and run tests for the Insta crate itself, you can clone this
+repository and run:
+
+```
+$ make build
+$ make test
+```
+
 ## License
 
 Insta is licensed under the Apache 2 license.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ $ make build
 $ make test
 ```
 
+You can also start a readily configured online workspace using Gitpod:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://github.com/mitsuhiko/insta)
+
 ## License
 
 Insta is licensed under the Apache 2 license.


### PR DESCRIPTION
Hello!

In this pull request, I am proposing two changes:

1. Document local development steps using `make` (I initially tried `cargo build` and `cargo test`, which didn't work, see #2)
2. Optionally, I've also added Gitpod support in order to make contributions easier for newcomers

Disclaimer: I work on [Gitpod](https://gitpod.io), an online development service that's free for open source. We'd love to help new Insta contributors by providing free pre-configured workspaces in the cloud. I've configured Gitpod to automatically run `make build` and `make test` in all new Insta workspaces.

Here is what it looks like:

<img width="1552" alt="screenshot 2019-01-16 at 18 36 05" src="https://user-images.githubusercontent.com/599268/51267277-9faded80-19bd-11e9-88f5-d943c941f87a.png">

You can try it here:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io#snapshot/e52f8255-bc6f-491d-9575-363cda790da5)

Please have a look when you have time and let me know what you think. 🙂 