### PR TITLE
Avoid downloading metadata for all dependencies

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -123,6 +123,7 @@ fn get_cargo_workspace(manifest_dir: &str) -> &Path {
         let output = std::process::Command::new(get_cargo())
             .arg("metadata")
             .arg("--format-version=1")
+            .arg("--no-deps")
             .current_dir(manifest_dir)
             .output()
             .unwrap();


### PR DESCRIPTION
While creating docker image for CI, I found that it is necessary to have SSL certs installed for running tests. It looks like this behavior can be avoided by adding one more option to cargo.
With this change it won't be necessary to have internet connection in order to run tests.