### PR TITLE
Use lowercase `a` when priting accept message

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -126,7 +126,7 @@ fn query_snapshot(
     println!();
     println!(
         "  {} accept   {}",
-        style("A").green().bold(),
+        style("a").green().bold(),
         style("keep the new snapshot").dim()
     );
     println!(


### PR DESCRIPTION
We don't actually accept on uppercase `A`!