### PR TITLE
fixing search for Inline snapshot after a skip.

### DIFF
--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -126,7 +126,15 @@ impl FilePatcher {
 
         impl<'ast> syn::visit::Visit<'ast> for Visitor {
             fn visit_macro(&mut self, i: &'ast syn::Macro) {
-                if i.span().start().line != self.0 || i.path.segments.is_empty() {
+                let start = i.span().start().line;
+                let end = i
+                    .tts
+                    .clone()
+                    .into_iter()
+                    .last()
+                    .map_or(start, |t| t.span().end().line);
+
+                if start > self.0 || end < self.0 || i.path.segments.is_empty() {
                     return;
                 }
 


### PR DESCRIPTION
The InLine FilePatcher wasn't finding the correct snapshot (or even finding it at all) after a previous "skip". 

I don't think the line number check is sufficient. 

If you want some unit tests: try mine  https://bitbucket.org/athaliana/typescript-definitions/src/master/tests/typescript.rs