### PR TITLE
Retain YAML --- header in inline YAML snapshots

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,6 @@ pub mod _macro_support {
     pub use crate::redaction::Selector;
     pub use crate::runtime::{assert_snapshot, ReferenceValue};
     pub use crate::serialization::{
-        serialize_value, serialize_value_redacted, SerializationFormat,
+        serialize_value, serialize_value_redacted, SerializationFormat, SnapshotLocation,
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -137,7 +137,8 @@ macro_rules! _assert_serialized_snapshot_matches {
     ($value:expr, $format:ident, @$snapshot:literal) => {{
         let value = $crate::_macro_support::serialize_value(
             &$value,
-            $crate::_macro_support::SerializationFormat::$format
+            $crate::_macro_support::SerializationFormat::$format,
+            $crate::_macro_support::SnapshotLocation::Inline
         );
         $crate::assert_snapshot_matches!(
             value,
@@ -155,14 +156,16 @@ macro_rules! _assert_serialized_snapshot_matches {
         let value = $crate::_macro_support::serialize_value_redacted(
             &$value,
             &vec,
-            $crate::_macro_support::SerializationFormat::$format
+            $crate::_macro_support::SerializationFormat::$format,
+            $crate::_macro_support::SnapshotLocation::Inline
         );
         $crate::assert_snapshot_matches!(value, stringify!($value), @$snapshot);
     }};
     ($name:expr, $value:expr, $format:ident) => {{
         let value = $crate::_macro_support::serialize_value(
             &$value,
-            $crate::_macro_support::SerializationFormat::$format
+            $crate::_macro_support::SerializationFormat::$format,
+            $crate::_macro_support::SnapshotLocation::File
         );
         $crate::assert_snapshot_matches!(
             $name,
@@ -180,7 +183,8 @@ macro_rules! _assert_serialized_snapshot_matches {
         let value = $crate::_macro_support::serialize_value_redacted(
             &$value,
             &vec,
-            $crate::_macro_support::SerializationFormat::$format
+            $crate::_macro_support::SerializationFormat::$format,
+            $crate::_macro_support::SnapshotLocation::File
         );
         $crate::assert_snapshot_matches!($name, value, stringify!($value));
     }}

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -63,7 +63,8 @@ fn test_yaml_inline() {
         id: 42,
         username: "peter-pan".into(),
         email: "peterpan@wonderland.invalid".into()
-    }, @r###"id: 42
+    }, @r###"---
+id: 42
 username: peter-pan
 email: peterpan@wonderland.invalid"###);
 }
@@ -83,7 +84,8 @@ fn test_yaml_inline_redacted() {
         email: "peterpan@wonderland.invalid".into()
     }, {
         ".id" => "[user-id]"
-    }, @r###"id: "[user-id]"
+    }, @r###"---
+id: "[user-id]"
 username: peter-pan
 email: peterpan@wonderland.invalid"###);
 }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -51,6 +51,24 @@ fn test_json_inline() {
 }
 
 #[test]
+fn test_yaml_inline() {
+    #[derive(Serialize)]
+    pub struct User {
+        id: u32,
+        username: String,
+        email: String,
+    }
+
+    assert_yaml_snapshot_matches!(User {
+        id: 42,
+        username: "peter-pan".into(),
+        email: "peterpan@wonderland.invalid".into()
+    }, @r###"id: 42
+username: peter-pan
+email: peterpan@wonderland.invalid"###);
+}
+
+#[test]
 fn test_yaml_inline_redacted() {
     #[derive(Serialize)]
     pub struct User {


### PR DESCRIPTION
Closes #22 

The primary change was to introduce a new `SnapshotLocation` enum; it's intended to track where a snapshot is being stored – inline vs in a `.snap` file. I updated the various macro calls to just use it as a third parameter to `serialize_value` / `serialize_value_redacted`, which seemed simplest to me.

The new behavior is as follows:

> If a YAML snapshot is inline, we don't trim the leading `---\n`; in all other cases, we maintain the existing behavior.