### PR TITLE
Improve indentation of inline snapshots

### DIFF
--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -270,7 +270,7 @@ impl Package {
 
     pub fn iter_snapshot_containers<'a>(
         &self,
-        extensions: &'a [&'a str]
+        extensions: &'a [&'a str],
     ) -> impl Iterator<Item = Result<SnapshotContainer, Error>> + 'a {
         let mut roots = HashSet::new();
         for target in &self.targets {
@@ -286,7 +286,9 @@ impl Package {
                 roots.insert(root.to_path_buf());
             }
         }
-        roots.into_iter().flat_map(move |root| find_snapshots(root, extensions))
+        roots
+            .into_iter()
+            .flat_map(move |root| find_snapshots(root, extensions))
     }
 }
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -174,11 +174,7 @@ fn handle_color(color: &Option<String>) -> Result<(), Error> {
 fn handle_target_args(
     target_args: &TargetArgs,
 ) -> Result<(PathBuf, Option<Vec<Package>>, Vec<&str>), Error> {
-    let mut exts: Vec<&str> = target_args
-        .extensions
-        .iter()
-        .map(|x| x.as_str())
-        .collect();
+    let mut exts: Vec<&str> = target_args.extensions.iter().map(|x| x.as_str()).collect();
     if exts.is_empty() {
         exts.push("snap");
     }

--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -104,7 +104,7 @@ impl FilePatcher {
                     }
                     *line = Cow::Owned(format!(
                         "{c: >width$}{line}",
-                        c = "│",
+                        c = "⋮",
                         width = inline.indentation,
                         line = line
                     ));

--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -11,6 +12,7 @@ use syn::spanned::Spanned;
 pub struct InlineSnapshot {
     start: (usize, usize),
     end: (usize, usize),
+    indentation: usize,
 }
 
 #[derive(Debug)]
@@ -86,10 +88,37 @@ impl FilePatcher {
             .collect();
 
         // replace lines
-        let mut new_lines: Vec<_> = snapshot.lines().collect();
+        let mut new_lines: Vec<_> = snapshot.lines().map(Cow::Borrowed).collect();
         if new_lines.is_empty() {
-            new_lines.push("");
+            new_lines.push(Cow::Borrowed(""));
         }
+
+        // if we have more than one line we want to change into the block
+        // representation mode
+        if new_lines.len() > 1 || snapshot.contains('┇') {
+            new_lines.insert(0, Cow::Borrowed(""));
+            if inline.indentation > 0 {
+                for (idx, line) in new_lines.iter_mut().enumerate() {
+                    if idx == 0 {
+                        continue;
+                    }
+                    *line = Cow::Owned(format!(
+                        "{c: >width$}{line}",
+                        c = "│",
+                        width = inline.indentation,
+                        line = line
+                    ));
+                }
+                new_lines.push(Cow::Owned(format!(
+                    "{c: >width$}",
+                    c = " ",
+                    width = inline.indentation
+                )));
+            } else {
+                new_lines.push(Cow::Borrowed(""));
+            }
+        }
+
         let (quote_start, quote_end) =
             if new_lines.len() > 1 || new_lines[0].contains(&['\\', '"'][..]) {
                 ("r###\"", "\"###")
@@ -126,6 +155,7 @@ impl FilePatcher {
 
         impl<'ast> syn::visit::Visit<'ast> for Visitor {
             fn visit_macro(&mut self, i: &'ast syn::Macro) {
+                let indentation = i.span().start().column;
                 let start = i.span().start().line;
                 let end = i
                     .tts
@@ -164,7 +194,11 @@ impl FilePatcher {
                     _ => return,
                 };
 
-                self.1 = Some(InlineSnapshot { start, end });
+                self.1 = Some(InlineSnapshot {
+                    start,
+                    end,
+                    indentation,
+                });
             }
         }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -186,13 +186,13 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
     for (i, (mode, lineno, line)) in lines.iter().enumerate() {
         match mode {
             Mode::Add => println!(
-                "{:>5} │{}{}",
+                "{:>5} ⋮{}{}",
                 style(lineno).dim().bold(),
                 style("+").green(),
                 style(line).green()
             ),
             Mode::Rem => println!(
-                "{:>5} │{}{}",
+                "{:>5} ⋮{}{}",
                 style(lineno).dim().bold(),
                 style("-").red(),
                 style(line).red()
@@ -203,7 +203,7 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
                     .any(|x| x.0 != Mode::Same)
                 {
                     println!(
-                        "{:>5} │ {}",
+                        "{:>5} ⋮ {}",
                         style(lineno).dim().bold(),
                         style(line).dim()
                     );
@@ -379,11 +379,11 @@ fn generate_snapshot_name_for_thread(module_path: &str) -> String {
 }
 
 /// Helper function that returns the real inline snapshot value from a given
-/// frozen value string.  If the string starts with the '│' character
+/// frozen value string.  If the string starts with the '⋮' character
 /// (optionally prefixed by whitespace) the alternative serialization format
 /// is picked which has slightly improved indentation semantics.
 fn get_inline_snapshot_value(frozen_value: &str) -> String {
-    if frozen_value.trim_start().starts_with('│') {
+    if frozen_value.trim_start().starts_with('⋮') {
         let mut buf = String::new();
         let mut line_iter = frozen_value.lines();
         let mut indentation = 0;
@@ -394,7 +394,7 @@ fn get_inline_snapshot_value(frozen_value: &str) -> String {
                 continue;
             }
             indentation = line.len() - line_trimmed.len();
-            // 3 because '│' is three utf-8 bytes long
+            // 3 because '⋮' is three utf-8 bytes long
             buf.push_str(&line_trimmed[3..]);
             buf.push('\n');
             break;
@@ -407,8 +407,8 @@ fn get_inline_snapshot_value(frozen_value: &str) -> String {
                 }
             }
             if let Some(remainer) = line.get(indentation..) {
-                if remainer.starts_with('│') {
-                    // 3 because '│' is three utf-8 bytes long
+                if remainer.starts_with('⋮') {
+                    // 3 because '⋮' is three utf-8 bytes long
                     buf.push_str(&remainer[3..]);
                     buf.push('\n');
                 } else if remainer.trim().is_empty() {

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -378,6 +378,57 @@ fn generate_snapshot_name_for_thread(module_path: &str) -> String {
     rv
 }
 
+/// Helper function that returns the real inline snapshot value from a given
+/// frozen value string.  If the string starts with the '│' character
+/// (optionally prefixed by whitespace) the alternative serialization format
+/// is picked which has slightly improved indentation semantics.
+fn get_inline_snapshot_value(frozen_value: &str) -> String {
+    if frozen_value.trim_start().starts_with('│') {
+        let mut buf = String::new();
+        let mut line_iter = frozen_value.lines();
+        let mut indentation = 0;
+
+        for line in &mut line_iter {
+            let line_trimmed = line.trim_start();
+            if line_trimmed.is_empty() {
+                continue;
+            }
+            indentation = line.len() - line_trimmed.len();
+            // 3 because '│' is three utf-8 bytes long
+            buf.push_str(&line_trimmed[3..]);
+            buf.push('\n');
+            break;
+        }
+
+        for line in &mut line_iter {
+            if let Some(prefix) = line.get(..indentation) {
+                if !prefix.trim().is_empty() {
+                    return "".to_string();
+                }
+            }
+            if let Some(remainer) = line.get(indentation..) {
+                if remainer.starts_with('│') {
+                    // 3 because '│' is three utf-8 bytes long
+                    buf.push_str(&remainer[3..]);
+                    buf.push('\n');
+                } else if remainer.trim().is_empty() {
+                    continue;
+                } else {
+                    return "".to_string();
+                }
+            }
+        }
+
+        if buf.ends_with('\n') {
+            buf.truncate(buf.len() - 1);
+        }
+
+        buf
+    } else {
+        frozen_value.to_string()
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn assert_snapshot(
     refval: ReferenceValue<'_>,
@@ -425,7 +476,7 @@ pub fn assert_snapshot(
                         created,
                         ..MetaData::default()
                     },
-                    contents.to_string(),
+                    get_inline_snapshot_value(contents),
                 )),
                 Some(filename),
             )

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -35,11 +35,13 @@ fn test_ron_inline() {
         id: 42,
         username: "peter-doe".into(),
         email: Email("peter@doe.invalid".into()),
-    }, @r###"User(
-  id: 42,
-  username: "peter-doe",
-  email: Email("peter@doe.invalid"),
-)"###);
+    }, @r###"
+   │User(
+   │  id: 42,
+   │  username: "peter-doe",
+   │  email: Email("peter@doe.invalid"),
+   │)
+    "###);
 }
 
 #[test]
@@ -63,10 +65,12 @@ fn test_yaml_inline() {
         id: 42,
         username: "peter-pan".into(),
         email: "peterpan@wonderland.invalid".into()
-    }, @r###"---
-id: 42
-username: peter-pan
-email: peterpan@wonderland.invalid"###);
+    }, @r###"
+   │---
+   │id: 42
+   │username: peter-pan
+   │email: peterpan@wonderland.invalid
+    "###);
 }
 
 #[test]
@@ -84,8 +88,10 @@ fn test_yaml_inline_redacted() {
         email: "peterpan@wonderland.invalid".into()
     }, {
         ".id" => "[user-id]"
-    }, @r###"---
-id: "[user-id]"
-username: peter-pan
-email: peterpan@wonderland.invalid"###);
+    }, @r###"
+   │---
+   │id: "[user-id]"
+   │username: peter-pan
+   │email: peterpan@wonderland.invalid
+    "###);
 }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -36,11 +36,11 @@ fn test_ron_inline() {
         username: "peter-doe".into(),
         email: Email("peter@doe.invalid".into()),
     }, @r###"
-   │User(
-   │  id: 42,
-   │  username: "peter-doe",
-   │  email: Email("peter@doe.invalid"),
-   │)
+   ⋮User(
+   ⋮  id: 42,
+   ⋮  username: "peter-doe",
+   ⋮  email: Email("peter@doe.invalid"),
+   ⋮)
     "###);
 }
 
@@ -66,10 +66,10 @@ fn test_yaml_inline() {
         username: "peter-pan".into(),
         email: "peterpan@wonderland.invalid".into()
     }, @r###"
-   │---
-   │id: 42
-   │username: peter-pan
-   │email: peterpan@wonderland.invalid
+   ⋮---
+   ⋮id: 42
+   ⋮username: peter-pan
+   ⋮email: peterpan@wonderland.invalid
     "###);
 }
 
@@ -89,9 +89,9 @@ fn test_yaml_inline_redacted() {
     }, {
         ".id" => "[user-id]"
     }, @r###"
-   │---
-   │id: "[user-id]"
-   │username: peter-pan
-   │email: peterpan@wonderland.invalid
+   ⋮---
+   ⋮id: "[user-id]"
+   ⋮username: peter-pan
+   ⋮email: peterpan@wonderland.invalid
     "###);
 }


### PR DESCRIPTION
This fixes #28

Not happy with the choice of character yet (`│`) which seems to have some bad drawing artifacts in vscode.