### PR TITLE
Snapshot transformation over a directory

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -321,8 +321,7 @@ macro_rules! _assert_snapshot_matches {
                     file!(),
                     line!(),
                     $debug_expr,
-                )
-                .unwrap();
+                );
             }
         }
     };


### PR DESCRIPTION
Closes #31

Progress:
- [X] Refactor `runtime.rs` to not write directly to the terminal
- [ ] ...
- [ ] Provide high-level API for testing a transform on a directory of files