### PR TITLE
Rust 1.35 format changes

### DIFF
--- a/tests/snapshots/test_basic__debug_vector.snap
+++ b/tests/snapshots/test_basic__debug_vector.snap
@@ -1,11 +1,11 @@
 ---
-created: "2019-03-03T12:32:23.110499Z"
-creator: insta@0.6.3
+created: "2019-05-29T04:21:15.246465Z"
+creator: insta@0.8.1
 source: tests/test_basic.rs
 expression: "vec![1 , 2 , 3]"
 ---
 [
     1,
     2,
-    3
+    3,
 ]

--- a/tests/snapshots/test_basic__unnamed_debug_vector-2.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector-2.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-03-05T09:03:05.339291Z"
-creator: insta@0.6.3
+created: "2019-05-29T04:22:50.837055Z"
+creator: insta@0.8.1
 source: tests/test_basic.rs
 expression: "vec![1 , 2 , 3 , 4]"
 ---
@@ -8,5 +8,5 @@ expression: "vec![1 , 2 , 3 , 4]"
     1,
     2,
     3,
-    4
+    4,
 ]

--- a/tests/snapshots/test_basic__unnamed_debug_vector-3.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector-3.snap
@@ -1,6 +1,6 @@
 ---
-created: "2019-03-05T09:03:05.376826Z"
-creator: insta@0.6.3
+created: "2019-05-29T04:23:34.575648Z"
+creator: insta@0.8.1
 source: tests/test_basic.rs
 expression: "vec![1 , 2 , 3 , 4 , 5]"
 ---
@@ -9,5 +9,5 @@ expression: "vec![1 , 2 , 3 , 4 , 5]"
     2,
     3,
     4,
-    5
+    5,
 ]

--- a/tests/snapshots/test_basic__unnamed_debug_vector.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector.snap
@@ -1,11 +1,11 @@
 ---
-created: "2019-03-05T09:03:05.274480Z"
-creator: insta@0.6.3
+created: "2019-05-29T04:21:15.246794Z"
+creator: insta@0.8.1
 source: tests/test_basic.rs
 expression: "vec![1 , 2 , 3]"
 ---
 [
     1,
     2,
-    3
+    3,
 ]

--- a/tests/snapshots/test_redaction__foo_bar.snap
+++ b/tests/snapshots/test_redaction__foo_bar.snap
@@ -1,18 +1,18 @@
-Created: 2019-01-20T22:01:30.388778+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo.bar").unwrap()
-Line: 26
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T14:16:16.625625Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo.bar\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
-            )
-        ]
-    ]
+                "bar",
+            ),
+        ],
+    ],
 }

--- a/tests/snapshots/test_redaction__foo_bar_alt.snap
+++ b/tests/snapshots/test_redaction__foo_bar_alt.snap
@@ -1,18 +1,18 @@
-Created: 2019-01-20T22:01:30.389866+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo[\"bar\"]").unwrap()
-Line: 27
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T14:53:37.492888Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo[\\\"bar\\\"]\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
-            )
-        ]
-    ]
+                "bar",
+            ),
+        ],
+    ],
 }

--- a/tests/snapshots/test_redaction__foo_bar_full_range.snap
+++ b/tests/snapshots/test_redaction__foo_bar_full_range.snap
@@ -1,22 +1,22 @@
-Created: 2019-01-20T22:01:30.390816+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo.bar[]").unwrap()
-Line: 28
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T15:01:31.190888Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo.bar[]\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
+                "bar",
             ),
             Range(
                 None,
-                None
-            )
-        ]
-    ]
+                None,
+            ),
+        ],
+    ],
 }

--- a/tests/snapshots/test_redaction__foo_bar_range.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range.snap
@@ -1,26 +1,26 @@
-Created: 2019-01-20T22:01:30.393618+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo.bar[10:20]").unwrap()
-Line: 31
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T15:02:21.911637Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo.bar[10:20]\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
+                "bar",
             ),
             Range(
                 Some(
-                    10
+                    10,
                 ),
                 Some(
-                    20
-                )
-            )
-        ]
-    ]
+                    20,
+                ),
+            ),
+        ],
+    ],
 }

--- a/tests/snapshots/test_redaction__foo_bar_range_from.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range_from.snap
@@ -1,24 +1,24 @@
-Created: 2019-01-20T22:01:30.392698+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo.bar[10:]").unwrap()
-Line: 30
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T15:01:53.352063Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo.bar[10:]\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
+                "bar",
             ),
             Range(
                 Some(
-                    10
+                    10,
                 ),
-                None
-            )
-        ]
-    ]
+                None,
+            ),
+        ],
+    ],
 }

--- a/tests/snapshots/test_redaction__foo_bar_range_to.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range_to.snap
@@ -1,24 +1,24 @@
-Created: 2019-01-20T22:01:30.391766+00:00
-Creator: insta@0.2.2
-Expression: Selector::parse(".foo.bar[:10]").unwrap()
-Line: 29
-Source: tests/test_redaction.rs
-
+---
+created: "2019-05-29T15:01:42.070559Z"
+creator: insta@0.8.1
+source: tests/test_redaction.rs
+expression: "Selector::parse(\".foo.bar[:10]\").unwrap()"
+---
 Selector {
     selectors: [
         [
             Key(
-                "foo"
+                "foo",
             ),
             Key(
-                "bar"
+                "bar",
             ),
             Range(
                 None,
                 Some(
-                    10
-                )
-            )
-        ]
-    ]
+                    10,
+                ),
+            ),
+        ],
+    ],
 }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -6,12 +6,14 @@ use serde::Serialize;
 
 #[test]
 fn test_simple() {
-    assert_debug_snapshot_matches!(vec![1, 2, 3, 4], @r###"[
-    1,
-    2,
-    3,
-    4
-]"###);
+    assert_debug_snapshot_matches!(vec![1, 2, 3, 4], @r###"
+   ⋮[
+   ⋮    1,
+   ⋮    2,
+   ⋮    3,
+   ⋮    4,
+   ⋮]
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
Edit: removed as changed focus of PR

<details>
 ...this is hidden, collapsable content...
Not sure why this didn't work:

```patch
diff --git src/runtime.rs src/runtime.rs
index bdb4d82..9281798 100644
--- src/runtime.rs
+++ src/runtime.rs
@@ -555,6 +555,7 @@ pub fn assert_snapshot(
     }
 
     if should_fail_in_tests() {
+        #[allow(clippy::assertions_on_constants)]
         assert!(
             false,
             "snapshot assertion for '{}' failed in line {}",

```
</details>

Any there any good first issues for those looking for some rust exposure and interested in expect tests?