### PR TITLE
Allow unnamed snapshots to compile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "0.8.1"
+version = "0.8.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -283,47 +283,35 @@ macro_rules! assert_display_snapshot_matches {
 #[macro_export]
 macro_rules! assert_snapshot_matches {
     ($value:expr, @$snapshot:literal) => {
-        $crate::_assert_snapshot_matches!(
+        assert_snapshot_matches!(
             $crate::_macro_support::ReferenceValue::Inline($snapshot),
             $value,
             stringify!($value)
         )
     };
     ($value:expr, $debug_expr:expr, @$snapshot:literal) => {
-        $crate::_assert_snapshot_matches!(
+        assert_snapshot_matches!(
             $crate::_macro_support::ReferenceValue::Inline($snapshot),
             $value,
             $debug_expr
         )
     };
     ($name:expr, $value:expr) => {
-        $crate::_assert_snapshot_matches!(From::from($name), $value, stringify!($value))
+        assert_snapshot_matches!($name, $value, stringify!($value))
     };
     ($name:expr, $value:expr, $debug_expr:expr) => {
-        $crate::_assert_snapshot_matches!(From::from($name), $value, $debug_expr)
+        $crate::_macro_support::assert_snapshot(
+            $name.into(),
+            &$value,
+            env!("CARGO_MANIFEST_DIR"),
+            module_path!(),
+            file!(),
+            line!(),
+            $debug_expr,
+        )
+        .unwrap();
     };
     ($value:expr) => {
-        $crate::_assert_snapshot_matches!(None::<String>, $value, stringify!($value))
-    };
-}
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _assert_snapshot_matches {
-    ($refval:expr, $value:expr, $debug_expr:expr) => {
-        match &$value {
-            value => {
-                $crate::_macro_support::assert_snapshot(
-                    $refval,
-                    value,
-                    env!("CARGO_MANIFEST_DIR"),
-                    module_path!(),
-                    file!(),
-                    line!(),
-                    $debug_expr,
-                )
-                .unwrap();
-            }
-        }
+        assert_snapshot_matches!(None::<String>, $value, stringify!($value))
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -283,21 +283,21 @@ macro_rules! assert_display_snapshot_matches {
 #[macro_export]
 macro_rules! assert_snapshot_matches {
     ($value:expr, @$snapshot:literal) => {
-        assert_snapshot_matches!(
+        $crate::assert_snapshot_matches!(
             $crate::_macro_support::ReferenceValue::Inline($snapshot),
             $value,
             stringify!($value)
         )
     };
     ($value:expr, $debug_expr:expr, @$snapshot:literal) => {
-        assert_snapshot_matches!(
+        $crate::assert_snapshot_matches!(
             $crate::_macro_support::ReferenceValue::Inline($snapshot),
             $value,
             $debug_expr
         )
     };
     ($name:expr, $value:expr) => {
-        assert_snapshot_matches!($name, $value, stringify!($value))
+        $crate::assert_snapshot_matches!($name, $value, stringify!($value))
     };
     ($name:expr, $value:expr, $debug_expr:expr) => {
         $crate::_macro_support::assert_snapshot(
@@ -312,6 +312,6 @@ macro_rules! assert_snapshot_matches {
         .unwrap();
     };
     ($value:expr) => {
-        assert_snapshot_matches!(None::<String>, $value, stringify!($value))
+        $crate::assert_snapshot_matches!(None::<String>, $value, stringify!($value))
     };
 }

--- a/tests/snapshots/test_inline__unnamed_single_line-2.snap
+++ b/tests/snapshots/test_inline__unnamed_single_line-2.snap
@@ -1,0 +1,7 @@
+---
+created: "2019-07-16T10:35:19.553505Z"
+creator: insta@0.8.1
+source: tests/test_inline.rs
+expression: "\"Testing-2\""
+---
+Testing-2

--- a/tests/snapshots/test_inline__unnamed_single_line.snap
+++ b/tests/snapshots/test_inline__unnamed_single_line.snap
@@ -1,0 +1,7 @@
+---
+created: "2019-07-16T10:31:50.245097Z"
+creator: insta@0.8.1
+source: tests/test_inline.rs
+expression: "\"Testing\""
+---
+Testing

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -22,6 +22,12 @@ fn test_single_line() {
 }
 
 #[test]
+fn test_unnamed_single_line() {
+    assert_snapshot_matches!("Testing");
+    assert_snapshot_matches!("Testing-2");
+}
+
+#[test]
 fn test_ron_inline() {
     #[derive(Serialize)]
     pub struct Email(String);


### PR DESCRIPTION
While looking into https://github.com/mitsuhiko/insta/issues/36, I 'cleaned up' this macro, along the margin.
Let me know if I missing anything