### PR TITLE
fix(thread): Fix thread naming for snapshots

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -405,6 +405,7 @@ fn generate_snapshot_name_for_thread(module_path: &str) -> String {
     let mut name = thread
         .name()
         .expect("test thread is unnamed, no snapshot name can be generated");
+    name = name.rsplit("::").next().unwrap();
     // we really do not care about poisoning here.
     let key = format!("{}::{}", module_path, name);
     let mut counters = TEST_NAME_COUNTERS.lock().unwrap_or_else(|x| x.into_inner());

--- a/tests/snapshots/test_inline__something-2.snap
+++ b/tests/snapshots/test_inline__something-2.snap
@@ -1,0 +1,7 @@
+---
+created: "2019-08-02T12:56:32.092623600Z"
+creator: insta@0.9.0
+source: tests/test_inline.rs
+expression: "\"Testing-thread-2\""
+---
+Testing-thread-2

--- a/tests/snapshots/test_inline__something.snap
+++ b/tests/snapshots/test_inline__something.snap
@@ -1,0 +1,7 @@
+---
+created: "2019-08-02T12:56:32.045665300Z"
+creator: insta@0.9.0
+source: tests/test_inline.rs
+expression: "\"Testing-thread\""
+---
+Testing-thread

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -3,6 +3,7 @@ use insta::{
     assert_snapshot_matches, assert_yaml_snapshot_matches,
 };
 use serde::Serialize;
+use std::thread;
 
 #[test]
 fn test_simple() {
@@ -25,6 +26,19 @@ fn test_single_line() {
 fn test_unnamed_single_line() {
     assert_snapshot_matches!("Testing");
     assert_snapshot_matches!("Testing-2");
+}
+
+#[test]
+fn test_unnamed_thread_single_line() {
+    let builder = thread::Builder::new()
+        .name("foo::lol::something".into());
+
+    let handler = builder.spawn(|| {
+        assert_snapshot_matches!("Testing-thread");
+        assert_snapshot_matches!("Testing-thread-2");
+    }).unwrap();
+
+    handler.join().unwrap();
 }
 
 #[test]


### PR DESCRIPTION
**Summary:**

Fix getting thread names by aligning it with module path
name extraction: only get the last `::` part.

**BREAKING:** This change is incompatible with past snapshots.

**Test plan:**

Added new snapshot tests with threads. Confirmed they
fail when the fix is reverted.