### PR TITLE
Encapsulate operations on Snapshot values into a struct SnapshotContents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,9 @@ pub use crate::snapshot::{MetaData, Snapshot};
 
 // exported for cargo-insta only
 #[doc(hidden)]
-pub use crate::{runtime::print_snapshot_diff, snapshot::PendingInlineSnapshot};
+pub use crate::{
+    runtime::print_snapshot_diff, snapshot::PendingInlineSnapshot, snapshot::SnapshotContents,
+};
 
 // these are here to make the macros work
 #[doc(hidden)]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,7 +20,7 @@ use ci_info::is_ci;
 use serde::Deserialize;
 use serde_json;
 
-use crate::snapshot::{MetaData, PendingInlineSnapshot, Snapshot};
+use crate::snapshot::{MetaData, PendingInlineSnapshot, Snapshot, SnapshotContents};
 
 lazy_static! {
     static ref WORKSPACES: Mutex<BTreeMap<String, &'static Path>> = Mutex::new(BTreeMap::new());
@@ -218,11 +218,7 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
         println!("{:─^1$}", "", width,);
         println!("{}", style(format_rust_expression(expr)).dim());
     }
-    println!(
-        "────────────┬{:─^1$}",
-        "",
-        width.saturating_sub(13),
-    );
+    println!("────────────┬{:─^1$}", "", width.saturating_sub(13),);
     for (i, (mode, lineno_a, lineno_b, line)) in lines.iter().enumerate() {
         match mode {
             Mode::Add => println!(
@@ -254,11 +250,7 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
             }
         }
     }
-    println!(
-        "────────────┴{:─^1$}",
-        "",
-        width.saturating_sub(13),
-    );
+    println!("────────────┴{:─^1$}", "", width.saturating_sub(13),);
 }
 
 pub fn get_snapshot_filename(
@@ -312,8 +304,8 @@ pub fn print_snapshot_diff(
         );
     }
     let changeset = Changeset::new(
-        old_snapshot.as_ref().map_or("", |x| x.contents()),
-        &new.contents(),
+        old_snapshot.as_ref().map_or("", |x| x.contents_str()),
+        &new.contents_str(),
         "\n",
     );
     if let Some(old_snapshot) = old_snapshot {
@@ -426,7 +418,10 @@ fn generate_snapshot_name_for_thread(module_path: &str) -> String {
 /// frozen value string.  If the string starts with the '⋮' character
 /// (optionally prefixed by whitespace) the alternative serialization format
 /// is picked which has slightly improved indentation semantics.
-fn get_inline_snapshot_value(frozen_value: &str) -> String {
+pub(super) fn get_inline_snapshot_value(frozen_value: &str) -> String {
+    // TODO: could move this into the SnapshotContents `from_inline` method
+    // (the only call site)
+
     if frozen_value.trim_start().starts_with('⋮') {
         let mut buf = String::new();
         let mut line_iter = frozen_value.lines();
@@ -522,16 +517,18 @@ pub fn assert_snapshot(
                         created,
                         ..MetaData::default()
                     },
-                    get_inline_snapshot_value(contents),
+                    SnapshotContents::from_inline(contents),
                 )),
                 Some(filename),
             )
         }
     };
 
+    let new_snapshot_contents: SnapshotContents = new_snapshot.into();
+
     // if the snapshot matches we're done.
-    if let Some(ref x) = old {
-        if x.contents().trim_end() == new_snapshot.trim_end() {
+    if let Some(ref old_snapshot) = old {
+        if old_snapshot.contents() == &new_snapshot_contents {
             return Ok(());
         }
     }
@@ -549,7 +546,7 @@ pub fn assert_snapshot(
             source: Some(path_to_storage(file)),
             expression: Some(expr.to_string()),
         },
-        new_snapshot.to_string(),
+        new_snapshot_contents,
     );
 
     print_snapshot_diff_with_title(

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -218,7 +218,11 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
         println!("{:─^1$}", "", width,);
         println!("{}", style(format_rust_expression(expr)).dim());
     }
-    println!("────────────┬{:─^1$}", "", width.saturating_sub(13),);
+    println!(
+        "────────────┬{:─^1$}",
+        "",
+        width.saturating_sub(13),
+    );
     for (i, (mode, lineno_a, lineno_b, line)) in lines.iter().enumerate() {
         match mode {
             Mode::Add => println!(
@@ -250,7 +254,11 @@ fn print_changeset(changeset: &Changeset, expr: Option<&str>) {
             }
         }
     }
-    println!("────────────┴{:─^1$}", "", width.saturating_sub(13),);
+    println!(
+        "────────────┴{:─^1$}",
+        "",
+        width.saturating_sub(13),
+    );
 }
 
 pub fn get_snapshot_filename(

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -97,7 +98,7 @@ pub struct Snapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
     snapshot_name: Option<String>,
     metadata: MetaData,
-    snapshot: String,
+    snapshot: SnapshotContents,
 }
 
 impl Snapshot {
@@ -188,7 +189,7 @@ impl Snapshot {
             module_name,
             snapshot_name,
             metadata,
-            buf,
+            buf.into(),
         ))
     }
 
@@ -197,7 +198,7 @@ impl Snapshot {
         module_name: String,
         snapshot_name: Option<String>,
         metadata: MetaData,
-        snapshot: String,
+        snapshot: SnapshotContents,
     ) -> Snapshot {
         Snapshot {
             module_name,
@@ -223,8 +224,13 @@ impl Snapshot {
     }
 
     /// The snapshot contents
-    pub fn contents(&self) -> &str {
+    pub fn contents(&self) -> &SnapshotContents {
         &self.snapshot
+    }
+
+    /// The snapshot contents as a &str
+    pub fn contents_str(&self) -> &str {
+        &self.snapshot.contents
     }
 
     pub(crate) fn save<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
@@ -235,8 +241,96 @@ impl Snapshot {
         let mut f = fs::File::create(&path)?;
         serde_yaml::to_writer(&mut f, &self.metadata)?;
         f.write_all(b"\n---\n")?;
-        f.write_all(self.snapshot.as_bytes())?;
+        f.write_all(self.contents_str().as_bytes())?;
         f.write_all(b"\n")?;
         Ok(())
     }
+}
+
+use super::runtime::get_inline_snapshot_value;
+
+/// The contents of a Snapshot
+// Could be Cow, but I think limited savings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SnapshotContents {
+    pub contents: String,
+}
+
+impl SnapshotContents {
+    pub fn from_inline(value: &str) -> SnapshotContents {
+        SnapshotContents {
+            contents: get_inline_snapshot_value(value),
+        }
+    }
+    pub fn to_inline(&self, indentation: usize) -> String {
+        denormalize_inline_snapshot(&self.contents, indentation)
+    }
+}
+
+impl From<&str> for SnapshotContents {
+    fn from(value: &str) -> SnapshotContents {
+        SnapshotContents {
+            contents: value.to_string(),
+        }
+    }
+}
+
+impl From<String> for SnapshotContents {
+    fn from(value: String) -> SnapshotContents {
+        SnapshotContents { contents: value }
+    }
+}
+
+impl From<SnapshotContents> for String {
+    fn from(value: SnapshotContents) -> String {
+        value.contents
+    }
+}
+
+impl PartialEq for SnapshotContents {
+    fn eq(&self, other: &Self) -> bool {
+        self.contents.trim_end() == other.contents.trim_end()
+    }
+}
+
+// from a snapshot to a string we want to write back
+fn denormalize_inline_snapshot(snapshot: &str, indentation: usize) -> String {
+    let mut out = String::new();
+    let is_escape = snapshot.lines().count() > 1 || snapshot.contains(&['\\', '"'][..]);
+
+    out.push_str(if is_escape { "r###\"" } else { "\"" });
+    let mut new_lines: Vec<_> = snapshot.lines().map(Cow::Borrowed).collect();
+    if new_lines.is_empty() {
+        new_lines.push(Cow::Borrowed(""));
+    }
+
+    // if we have more than one line we want to change into the block
+    // representation mode
+    if new_lines.len() > 1 || snapshot.contains('┇') {
+        new_lines.insert(0, Cow::Borrowed(""));
+        if indentation > 0 {
+            for (idx, line) in new_lines.iter_mut().enumerate() {
+                if idx == 0 {
+                    continue;
+                }
+                *line = Cow::Owned(format!(
+                    "{c: >width$}{line}",
+                    c = "⋮",
+                    width = indentation,
+                    line = line
+                ));
+            }
+            new_lines.push(Cow::Owned(format!(
+                "{c: >width$}",
+                c = " ",
+                width = indentation
+            )));
+        } else {
+            new_lines.push(Cow::Borrowed(""));
+        }
+    }
+
+    out.push_str(if is_escape { "\"###" } else { "\"" });
+
+    out
 }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,3 +1,4 @@
+use super::runtime::get_inline_snapshot_value;
 use std::borrow::Cow;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
@@ -246,8 +247,6 @@ impl Snapshot {
         Ok(())
     }
 }
-
-use super::runtime::get_inline_snapshot_value;
 
 /// The contents of a Snapshot
 // Could be Cow, but I think limited savings


### PR DESCRIPTION
Encapsulates:
- Reading from inline values
- Writing out to inline values with an indentation
- `PartialEq`, which previously was implemented inline
- Hopefully some others in the future

Somewhat overlapping with https://github.com/mitsuhiko/insta/pull/52; I tried to implement separately as this has no API impact. This can be merged first.

It's not a perfect API - there's now another method `Snapshot.contents_str` to get a `&str` directly - and I generally find adding types over primitives adds cruft
Open to any feedback / suggestions as ever