### PR TITLE
missing assert_serialized_snapshot_matches

### DIFF
--- a/src/legacy_macros.rs
+++ b/src/legacy_macros.rs
@@ -2,7 +2,7 @@
 #[macro_export]
 #[doc(hidden)]
 #[deprecated(since = "0.6.0", note = "Replaced by assert_yaml_snapshot")]
-macro_rules! assert_serialized_snapshot {
+macro_rules! assert_serialized_snapshot_matches {
     ($($t:tt)*) => { $crate::assert_serialized_snapshot!($($t)*); }
 }
 


### PR DESCRIPTION
I think with all the changes we missed `assert_serialized_snapshot_matches`