### PR TITLE
console 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serialization = []
 difference = "2.0.0"
 serde = { version = "1.0.85", features = ["derive"] }
 serde_yaml = "0.8.8"
-console = "0.8.0"
+console = "0.9.0"
 serde_json = "1.0.36"
 lazy_static = "1.2.0"
 pest = { version = "2.1.0", optional = true }


### PR DESCRIPTION
Bump console to 0.9.0 to remove dependencies on crates that depend on insta.