### PR TITLE
Bump console to 0.9.0 in cargo-insta

### DIFF
--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 insta = { version = "0.11.0", path = "..", features = ["redactions"] }
-console = "0.8.0"
+console = "0.9.0"
 clap = "2.32.0"
 difference = "2.0.0"
 structopt = "0.2.14"


### PR DESCRIPTION
Missed this in #74 