### PR TITLE
Bump uuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ lazy_static = "1.2.0"
 pest = { version = "2.1.0", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.5.1", optional = true }
-uuid = { version = "0.7.1", features = ["serde", "v4"] }
+uuid = { version = "0.8.1", features = ["serde", "v4"] }


### PR DESCRIPTION
Motivation is to allow downstream crates to drop older versions of rand. This PR is a stepping stone to that.