### PR TITLE
Remove identity conversion

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -35,7 +35,7 @@ enum UpdateBehavior {
 
 #[cfg(windows)]
 fn path_to_storage<P: AsRef<Path>>(path: P) -> String {
-    path.as_ref().to_str().unwrap().replace('\\', "/").into()
+    path.as_ref().to_str().unwrap().replace('\\', "/")
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
Clippy complained that there was an identity conversion. The function
`path_to_storage` returns a `String`. The call to `replace` inside
the `path_to_storage` function returns a `String`. That means the call
to `into` is not needed because the type is already a `String`.