### PR TITLE
Use full module path for test names

### DIFF
--- a/src/snapshots/insta__test__embedded.snap
+++ b/src/snapshots/insta__test__embedded.snap
@@ -1,0 +1,5 @@
+---
+source: src/test.rs
+expression: "\"Just a string\""
+---
+Just a string

--- a/src/snapshots/test__embedded.snap
+++ b/src/snapshots/test__embedded.snap
@@ -1,7 +1,0 @@
-Created: 2019-01-20T21:06:59.853399+00:00
-Creator: insta@0.2.2
-Expression: "Just a string"
-Line: 3
-Source: src/test.rs
-
-Just a string

--- a/tests/snapshots/test_basic__nested__nested_module.snap
+++ b/tests/snapshots/test_basic__nested__nested_module.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_basic.rs
+expression: "\"aoeu\""
+---
+aoeu

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -39,6 +39,14 @@ fn test_unnamed_json_vector() {
     assert_json_snapshot!(vec![1, 2, 3, 4, 5]);
 }
 
+mod nested {
+    #[test]
+    fn test_nested_module() {
+        use insta::assert_snapshot;
+        assert_snapshot!("aoeu");
+    }
+}
+
 struct TestDisplay;
 
 impl fmt::Display for TestDisplay {


### PR DESCRIPTION
Closes https://github.com/mitsuhiko/insta/issues/78

Is this the right design? A good case is the `insta__test__embedded.snap` change below. I suspect those cases are rare; though it's a breaking change where they do exist.

I need to adds a whatsnew