### PR TITLE
Add support for test name recovery from the call stack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,4 @@ lazy_static = "1.4.0"
 pest = { version = "2.1.0", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.5.1", optional = true }
+backtrace = { version = "0.3.42", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ cargotest:
 	@cargo test
 	@cargo test --all-features
 	@cargo test --no-default-features
+	@cargo test --features redactions,backtrace -- --test-threads 1
 	@cd cargo-insta; cargo test
 
 format:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## What are snapshot tests
 
 Snapshots tests (also sometimes called approval tests) are tests that
-assert values against a reference value (the snapshot). This is similar
+assert values against a reference value (the snapshot).  This is similar
 to how `assert_eq!` lets you compare a value against a reference value but
 unlike simple string assertions snapshot tests let you test against complex
 values and come with comprehensive tools to review changes.
@@ -31,16 +31,16 @@ This crate exports multiple macros for snapshot testing:
   types implementing `serde::Serialize`.
 
 Snapshots are stored in the `snapshots` folder right next to the test file
-where this is used. The name of the file is `<module>__<name>.snap` where
-the `name` of the snapshot. Snapshots can either be explicitly named or the
+where this is used.  The name of the file is `<module>__<name>.snap` where
+the `name` of the snapshot.  Snapshots can either be explicitly named or the
 name is derived from the test name.
 
-Additionally snapshots can also be stored inline. In that case the
+Additionally snapshots can also be stored inline.  In that case the
 [`cargo-insta`](https://crates.io/crates/cargo-insta) tool is necessary.
 See [inline snapshots](#inline-snapshots) for more information.
 
 For macros that work with `serde::Serialize` this crate also permits
-redacting of partial values. See [redactions](#redactions) for more
+redacting of partial values.  See [redactions](#redactions) for more
 information.
 
 ## What it looks like:
@@ -82,9 +82,9 @@ fn test_snapshots() {
 ```
 
 The recommended flow is to run the tests once, have them fail and check
-if the result is okay. By default the new snapshots are stored next
-to the old ones with the extra `.new` extension. Once you are satisifed
-move the new files over. To simplify this workflow you can use
+if the result is okay.  By default the new snapshots are stored next
+to the old ones with the extra `.new` extension.  Once you are satisifed
+move the new files over.  To simplify this workflow you can use
 `cargo insta review` which will let you interactively review them:
 
 ```rust
@@ -94,7 +94,7 @@ $ cargo insta review
 
 For more information on updating see [Snapshot Updating].
 
-[snapshot updating]: #snapshot-updating
+[Snapshot Updating]: #snapshot-updating
 
 ## Snapshot files
 
@@ -116,7 +116,7 @@ source: tests/test_user.rs
 ## Snapshot updating
 
 During test runs snapshots will be updated according to the `INSTA_UPDATE`
-environment variable. The default is `auto` which will write all new
+environment variable.  The default is `auto` which will write all new
 snapshots into `.snap.new` files if no CI is detected.
 
 `INSTA_UPDATE` modes:
@@ -143,7 +143,7 @@ For more information invoke `cargo insta --help`.
 
 ## Test assertions
 
-By default the tests will fail when the snapshot assertion fails. However
+By default the tests will fail when the snapshot assertion fails.  However
 if a test produces more than one snapshot it can be useful to force a test
 to pass so that all new snapshots are created in one go.
 
@@ -167,8 +167,12 @@ which case the snapshot name is derived from the test name (with an optional
 leading `test_` prefix removed.
 
 This works because the rust test runner names the thread by the test name
-and the name is taken from the thread name. In case your test spawns additional
+and the name is taken from the thread name.  In case your test spawns additional
 threads this will not work and you will need to provide a name explicitly.
+There are some situations in which rust test does not name or use threads.
+In these cases insta will panic with an error.  The `backtrace` feature can
+be enabled in which case insta will attempt to recover the test name from
+the backtrace.
 
 Explicit snapshot naming can also otherwise be useful to be more explicit
 when multiple snapshots are tested within one function as the default
@@ -186,7 +190,7 @@ fn test_something() {
 ```
 
 This will create two snapshots: `first_snapshot` for the first value and
-`second_snapshot` for the second value. Without explicit naming the
+`second_snapshot` for the second value.  Without explicit naming the
 snapshots would be called `something` and `something-2`.
 
 ## Redactions
@@ -194,10 +198,10 @@ snapshots would be called `something` and `something-2`.
 **Feature:** `redactions`
 
 For all snapshots created based on `serde::Serialize` output `insta`
-supports redactions. This permits replacing values with hardcoded other
+supports redactions.  This permits replacing values with hardcoded other
 values to make snapshots stable when otherwise random or otherwise changing
-values are involved. Redactions became an optional feature in insta
-0.11 and can be enabled with the `redactions` feature./
+values are involved.  Redactions became an optional feature in insta
+0.11 and can be enabled with the `redactions` feature.
 
 Redactions can be defined as the third argument to those macros with
 the syntax `{ selector => replacement_value }`.
@@ -213,7 +217,7 @@ The following selectors exist:
 - `[start:end]`: selects all items from `start` to `end` (end excluding,
   supports negative indexing).
 - `.*`: selects all keys on that depth
-- `.**`: performs a deep match (zero or more items). Can only be used once.
+- `.**`: performs a deep match (zero or more items).  Can only be used once.
 
 Example usage:
 
@@ -257,10 +261,10 @@ assert_yaml_snapshot!(&User {
 
 ## Inline Snapshots
 
-Additionally snapshots can also be stored inline. In that case the format
+Additionally snapshots can also be stored inline.  In that case the format
 for the snapshot macros is `assert_snapshot!(reference_value, @"snapshot")`.
 The leading at sign (`@`) indicates that the following string is the
-reference value. `cargo-insta` will then update that string with the new
+reference value.  `cargo-insta` will then update that string with the new
 value on review.
 
 Example:
@@ -277,23 +281,23 @@ assert_yaml_snapshot!(User {
 ```
 
 After the initial test failure you can run `cargo insta review` to
-accept the change. The file will then be updated automatically.
+accept the change.  The file will then be updated automatically.
 
 ## Features
 
 The following features exist:
 
-- `ron`: enables RON support (`assert_ron_snapshot!`)
-- `redactions`: enables support for redactions
+* `ron`: enables RON support (`assert_ron_snapshot!`)
+* `redactions`: enables support for redactions
 
 ## Settings
 
 There are some settings that can be changed on a per-thread (and thus
-per-test) basis. For more information see [settings](struct.Settings.html).
+per-test) basis.  For more information see [settings](struct.Settings.html).
 
 ## Legacy Snapshot Formats
 
-With insta 0.11 the snapshot format was improved for inline snapshots. The
+With insta 0.11 the snapshot format was improved for inline snapshots.  The
 old snapshot format will continue to be available but if you want to upgrade
 them make sure the tests pass first and then run the following command
 to force a rewrite of them all:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,10 @@
 //! This works because the rust test runner names the thread by the test name
 //! and the name is taken from the thread name.  In case your test spawns additional
 //! threads this will not work and you will need to provide a name explicitly.
+//! There are some situations in which rust test does not name or use threads.
+//! In these cases insta will panic with an error.  The `backtrace` feature can
+//! be enabled in which case insta will attempt to recover the test name from
+//! the backtrace.
 //!
 //! Explicit snapshot naming can also otherwise be useful to be more explicit
 //! when multiple snapshots are tested within one function as the default
@@ -195,7 +199,7 @@
 //! supports redactions.  This permits replacing values with hardcoded other
 //! values to make snapshots stable when otherwise random or otherwise changing
 //! values are involved.  Redactions became an optional feature in insta
-//! 0.11 and can be enabled with the `redactions` feature./
+//! 0.11 and can be enabled with the `redactions` feature.
 //!
 //! Redactions can be defined as the third argument to those macros with
 //! the syntax `{ selector => replacement_value }`.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -300,7 +300,11 @@ pub fn get_snapshot_filename(
     Settings::with(|settings| {
         root.join(base.parent().unwrap())
             .join(settings.snapshot_path())
-            .join(format!("{}__{}.snap", module_path, snapshot_name))
+            .join(format!(
+                "{}__{}.snap",
+                module_path.replace("::", "__"),
+                snapshot_name
+            ))
     })
 }
 
@@ -427,41 +431,38 @@ pub enum ReferenceValue<'a> {
 fn test_name_from_backtrace(module_path: &str) -> String {
     let backtrace = backtrace::Backtrace::new();
     let frames = backtrace.frames();
-    let mut state = 0;
+    let mut found_run_wrapper = false;
 
-    for (symbol, mangled_symbol) in frames
+    for symbol in frames
         .iter()
         .rev()
         .flat_map(|x| x.symbols())
         .filter_map(|x| x.name())
-        .filter_map(|x| x.as_str().map(|n| (x, n.trim_start_matches('_'))))
+        .map(|x| format!("{}", x))
     {
-        println!("{} [{}] -- {}", symbol, state, module_path);
-        if state == 0 && mangled_symbol.starts_with("ZN4test8run_test") {
-            state = 1;
-        } else if state == 1 && mangled_symbol == "rust_maybe_catch_panic" {
-            state = 2;
-        } else if state == 2 {
-            let demangled = format!("{}", symbol);
-            if demangled.starts_with(module_path) {
-                let mut rv = &demangled[..demangled.len() - 19];
-                if rv.ends_with("::{{closure}}") {
-                    rv = &rv[..rv.len() - 13];
-                }
-                return rv.to_string();
+        if !found_run_wrapper {
+            if symbol.starts_with("test::run_test::") {
+                found_run_wrapper = true;
             }
+        } else if symbol.starts_with(module_path) {
+            let mut rv = &symbol[..symbol.len() - 19];
+            if rv.ends_with("::{{closure}}") {
+                rv = &rv[..rv.len() - 13];
+            }
+            return rv.to_string();
         }
     }
 
-    panic!("cannot determine test name from backtrace");
+    panic!("Cannot determine test name from backtrace, no snapshot name can be generated.");
 }
 
-fn generate_snapshot_name_for_thread(module_name: &str, module_path: &str) -> String {
+fn generate_snapshot_name_for_thread(module_path: &str) -> String {
     let thread = thread::current();
+    #[allow(unused_mut)]
     let mut name = Cow::Borrowed(
         thread
             .name()
-            .expect("test thread is unnamed, no snapshot name can be generated"),
+            .expect("test thread is unnamed, no snapshot name can be generated."),
     );
     if name == "main" {
         #[cfg(feature = "backtrace")]
@@ -472,13 +473,15 @@ fn generate_snapshot_name_for_thread(module_name: &str, module_path: &str) -> St
         {
             panic!(
                 "tests run with disabled concurrency, automatic snapshot \
-                 name generation is not supported"
+                 name generation is not supported.  Consider using the \
+                 \"backtrace\" feature of insta which tries to recover test \
+                 names from the call stack."
             );
         }
     }
     let mut name = name.rsplit("::").next().unwrap();
     // we really do not care about poisoning here.
-    let key = format!("{}::{}", module_name, name);
+    let key = format!("{}::{}", module_path.replace("::", "__"), name);
     let mut counters = TEST_NAME_COUNTERS.lock().unwrap_or_else(|x| x.into_inner());
     let test_idx = counters.get(&key).cloned().unwrap_or(0) + 1;
     if name.starts_with("test_") {
@@ -784,17 +787,16 @@ pub fn assert_snapshot(
     line: u32,
     expr: &str,
 ) -> Result<(), Box<dyn Error>> {
-    let module_name = module_path.replace("::", "__");
     let cargo_workspace = get_cargo_workspace(manifest_dir);
 
     let (snapshot_name, snapshot_file, old, pending_snapshots) = match refval {
         ReferenceValue::Named(snapshot_name) => {
             let snapshot_name: Cow<str> = match snapshot_name {
                 Some(snapshot_name) => snapshot_name,
-                None => (generate_snapshot_name_for_thread(&module_name, module_path).into()),
+                None => (generate_snapshot_name_for_thread(module_path).into()),
             };
             let snapshot_file =
-                get_snapshot_filename(&module_name, &snapshot_name, &cargo_workspace, file);
+                get_snapshot_filename(module_path, &snapshot_name, &cargo_workspace, file);
             let old = if fs::metadata(&snapshot_file).is_ok() {
                 Some(Snapshot::from_file(&snapshot_file)?)
             } else {
@@ -803,7 +805,7 @@ pub fn assert_snapshot(
             (snapshot_name, Some(snapshot_file), old, None)
         }
         ReferenceValue::Inline(contents) => {
-            let snapshot_name = generate_snapshot_name_for_thread(&module_name, module_path);
+            let snapshot_name = generate_snapshot_name_for_thread(module_path);
             let mut filename = cargo_workspace.join(file);
             filename.set_file_name(format!(
                 ".{}.pending-snap",
@@ -817,7 +819,7 @@ pub fn assert_snapshot(
                 Cow::Owned(snapshot_name),
                 None,
                 Some(Snapshot::from_components(
-                    module_name.to_string(),
+                    module_path.replace("::", "__"),
                     None,
                     MetaData::default(),
                     SnapshotContents::from_inline(contents),
@@ -829,7 +831,7 @@ pub fn assert_snapshot(
 
     let new_snapshot_contents: SnapshotContents = new_snapshot.into();
     let new = Snapshot::from_components(
-        module_name.to_string(),
+        module_path.replace("::", "__"),
         Some(snapshot_name.to_string()),
         MetaData {
             source: Some(path_to_storage(file)),


### PR DESCRIPTION
In some situations rust-test does not set a thread name when it runs tests
which causes snapshots to be named "main".  This is a pretty bad behavior
because it means that depending on how you run the tests the snapshot names
will be different.

This now adds a new feature `backtrace`.  There we will try to recover
the test name from the call stack.

This is not ideal.  Ideally there was an API to determine the test name
from an API.

This fixes #94