### PR TITLE
Check more doc code blocks

### DIFF
--- a/cargo-insta/src/main.rs
+++ b/cargo-insta/src/main.rs
@@ -5,7 +5,7 @@
 //!
 //! This crate provides a cargo command for insta snapshot reviews.
 //!
-//! ```ignore
+//! ```text
 //! $ cargo install cargo-insta
 //! $ cargo insta --help
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,8 @@
 //!
 //! Example usage:
 //!
-#![cfg_attr(feature = "redactions", doc = " ```no_run")]
-#![cfg_attr(not(feature = "redactions"), doc = " ```ignore")]
+//! ```no_run
+//! # #[cfg(feature = "redactions")] {
 //! # use insta::*; use serde::Serialize; use std::collections::HashMap;
 //! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! #[derive(Serialize)]
@@ -253,14 +253,15 @@
 //!     ".id" => "[uuid]",
 //!     ".extra.ssn" => "[ssn]"
 //! });
+//! # }
 //! ```
 //!
 //! It's also possible to execute a callback that can produce a new value
 //! instead of hardcoding a replacement value by using the
 //! [`dynamic_redaction`](fn.dynamic_redaction.html) function:
 //!
-#![cfg_attr(feature = "redactions", doc = " ```no_run")]
-#![cfg_attr(not(feature = "redactions"), doc = " ```ignore")]
+//! ```no_run
+//! # #[cfg(feature = "redactions")] {
 //! # use insta::*; use serde::Serialize;
 //! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! # #[derive(Serialize)]
@@ -277,6 +278,7 @@
 //!         "[uuid]"
 //!     }),
 //! });
+//! # }
 //! ```
 //!
 //! # Inline Snapshots

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,8 @@
 //!
 //! Example usage:
 //!
-//! ```no_run
+#![cfg_attr(feature = "redactions", doc = " ```no_run")]
+#![cfg_attr(not(feature = "redactions"), doc = " ```ignore")]
 //! # use insta::*; use serde::Serialize; use std::collections::HashMap;
 //! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! #[derive(Serialize)]
@@ -258,7 +259,8 @@
 //! instead of hardcoding a replacement value by using the
 //! [`dynamic_redaction`](fn.dynamic_redaction.html) function:
 //!
-//! ```no_run
+#![cfg_attr(feature = "redactions", doc = " ```no_run")]
+#![cfg_attr(not(feature = "redactions"), doc = " ```ignore")]
 //! # use insta::*; use serde::Serialize;
 //! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! # #[derive(Serialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! Recommended way if you have `cargo-edit` installed:
 //!
-//! ```ignore
+//! ```text
 //! $ cargo add --dev insta
 //! ```
 //!
@@ -65,11 +65,11 @@
 //!
 //! And for an improved review experience also install `cargo-insta`:
 //!
-//! ```ignore
+//! ```text
 //! $ cargo install cargo-insta
 //! ```
 //!
-//! ```rust,ignore
+//! ```no_run
 //! use insta::assert_debug_snapshot;
 //!
 //! #[test]
@@ -85,7 +85,7 @@
 //! move the new files over.  To simplify this workflow you can use
 //! `cargo insta review` which will let you interactively review them:
 //!
-//! ```ignore
+//! ```text
 //! $ cargo test
 //! $ cargo insta review
 //! ```
@@ -99,7 +99,7 @@
 //! The committed snapshot files will have a header with some meta information
 //! that can make debugging easier and the snapshot:
 //!
-//! ```ignore
+//! ```text
 //! ---
 //! expression: "&User{id: Uuid::new_v4(), username: \"john_doe\".to_string(),}"
 //! source: tests/test_user.rs
@@ -128,7 +128,7 @@
 //! When `new` is used as mode the `cargo-insta` command can be used to review
 //! the snapshots conveniently:
 //!
-//! ```ignore
+//! ```text
 //! $ cargo install cargo-insta
 //! $ cargo test
 //! $ cargo insta review
@@ -147,14 +147,14 @@
 //!
 //! This can be enabled by setting `INSTA_FORCE_PASS` to `1`:
 //!
-//! ```ignore
+//! ```text
 //! $ INSTA_FORCE_PASS=1 cargo test --no-fail-fast
 //! ```
 //!
 //! A better way to do this is to run `cargo insta test --review` which will
 //! run all tests with force pass and then bring up the review tool:
 //!
-//! ```ignore
+//! ```text
 //! $ cargo insta test --review
 //! ```
 //!
@@ -179,7 +179,7 @@
 //! To provide an explicit name provide the name of the snapshot as first
 //! argument to the macro:
 //!
-//! ```rust,ignore
+//! ```no_run
 //! #[test]
 //! fn test_something() {
 //!     assert_snapshot!("first_snapshot", "first value");
@@ -230,7 +230,9 @@
 //!
 //! Example usage:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # use insta::*; use serde::Serialize; use std::collections::HashMap;
+//! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! #[derive(Serialize)]
 //! pub struct User {
 //!     id: Uuid,
@@ -256,7 +258,9 @@
 //! instead of hardcoding a replacement value by using the
 //! [`dynamic_redaction`](fn.dynamic_redaction.html) function:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # use insta::*; use serde::Serialize;
+//! # #[derive(Serialize)] struct Uuid; impl Uuid { fn new_v4() -> Self { Uuid } }
 //! # #[derive(Serialize)]
 //! # pub struct User {
 //! #     id: Uuid,
@@ -283,7 +287,8 @@
 //!
 //! Example:
 //!
-//! ```rust,ignore
+//! ```no_run
+//! # use insta::*; use serde::Serialize;
 //! #[derive(Serialize)]
 //! pub struct User {
 //!     username: String,
@@ -316,7 +321,7 @@
 //! them make sure the tests pass first and then run the following command
 //! to force a rewrite of them all:
 //!
-//! ```text,ignore
+//! ```text
 //! $ cargo insta test --accept --force-update-snapshots
 //! ```
 #[macro_use]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -9,8 +9,9 @@
 ///
 /// Example:
 ///
-/// ```no_run,ignore
-/// assert_yaml_snapshot!(vec[1, 2, 3]);
+/// ```no_run
+/// # use insta::*;
+/// assert_yaml_snapshot!(vec![1, 2, 3]);
 /// ```
 ///
 /// Unlike the [`assert_debug_snapshot`](macros.assert_debug_snapshot.html)
@@ -22,7 +23,9 @@
 ///
 /// Example:
 ///
-/// ```no_run,ignore
+/// ```no_run
+/// # use insta::*; use serde::Serialize;
+/// # #[derive(Serialize)] struct Value; let value = Value;
 /// assert_yaml_snapshot!(value, {
 ///     ".key.to.redact" => "[replacement value]",
 ///     ".another.key.*.to.redact" => 42
@@ -70,8 +73,9 @@ macro_rules! assert_yaml_snapshot {
 ///
 /// Example:
 ///
-/// ```no_run,ignore
-/// assert_ron_snapshot!(vec[1, 2, 3]);
+/// ```no_run
+/// # use insta::*;
+/// assert_ron_snapshot!(vec![1, 2, 3]);
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
@@ -111,8 +115,9 @@ macro_rules! assert_ron_snapshot {
 ///
 /// Example:
 ///
-/// ```no_run,ignore
-/// assert_json_snapshot!(vec[1, 2, 3]);
+/// ```no_run
+/// # use insta::*;
+/// assert_json_snapshot!(vec![1, 2, 3]);
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
@@ -264,7 +269,8 @@ macro_rules! assert_display_snapshot {
 /// a string to store as snapshot an does not apply any other transformations
 /// on it.  This is useful to build ones own primitives.
 ///
-/// ```no_run,ignore
+/// ```no_run
+/// # use insta::*;
 /// assert_snapshot!("reference value to snapshot");
 /// ```
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,7 +23,8 @@
 ///
 /// Example:
 ///
-/// ```no_run
+#[cfg_attr(feature = "redactions", doc = " ```no_run")]
+#[cfg_attr(not(feature = "redactions"), doc = " ```ignore")]
 /// # use insta::*; use serde::Serialize;
 /// # #[derive(Serialize)] struct Value; let value = Value;
 /// assert_yaml_snapshot!(value, {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -59,7 +59,7 @@ pub struct ActualSettings {
 ///
 /// Example:
 ///
-/// ```rust,ignore
+/// ```ignore
 /// use insta;
 ///
 /// let mut settings = insta::Settings::new();


### PR DESCRIPTION
This does two main things:

- For code blocks that are not Rust code, use ```` ```text```` rather than ```` ```ignore````
- For code blocks that are Rust code, use ```` ```no_run```` and not ```` ```ignore````, and make them compile so doc tests check they continue to compile