### PR TITLE
Add glob support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ default = []
 # snapshots.
 redactions = ["pest", "pest_derive"]
 
+# Glob support
+glob = ["globwalk"]
+
 # This feature is now just always enabled because we use yaml internally now.
 serialization = []
 
@@ -40,3 +43,4 @@ pest = { version = "2.1.0", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.5.1", optional = true }
 backtrace = { version = "0.3.42", optional = true }
+globwalk = { version = "0.8.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ The following features exist:
 
 * `ron`: enables RON support (`assert_ron_snapshot!`)
 * `redactions`: enables support for redactions
+* `glob`: enables support for globbing (`glob!`)
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ the `INSTA_OUTPUT` environment variable.  The following values are possible:
 
 * `diff` (default): prints the diffs
 * `summary`: prints only summaries (name of snapshot files etc.)
-* `minimal`: like `summary` but more minimal
+* `mimimal`: like `summary` but more minimal
 * `none`: insta will not output any extra information
 
 ## Redactions
@@ -269,6 +269,31 @@ assert_yaml_snapshot!(&User {
     }),
 });
 ```
+
+## Globbing
+
+**Feature:** `glob`
+
+Sometimes it can be useful to run code against multiple input files.
+The easiest way to accomplish this is to use the `glob!` macro which
+runs a closure for each input file that matches.  Before the closure
+is executed the settings are updated to set a reference to the input
+file and the appropriate snapshot suffix.
+
+Example:
+
+```rust
+use std::fs;
+
+glob!("inputs/*.txt", |path| {
+    let input = fs::read_to_string(path).unwrap();
+    assert_json_snapshot!(input.to_uppercase());
+});
+```
+
+The path to the glob macro is relative to the location of the test
+file.  It uses the [`globset`](https://crates.io/crates/globset) crate
+for actual glob operations.
 
 ## Inline Snapshots
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ the `INSTA_OUTPUT` environment variable.  The following values are possible:
 
 * `diff` (default): prints the diffs
 * `summary`: prints only summaries (name of snapshot files etc.)
-* `mimimal`: like `summary` but more minimal
+* `minimal`: like `summary` but more minimal
 * `none`: insta will not output any extra information
 
 ## Redactions

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -1,0 +1,26 @@
+use std::path::Path;
+
+use globwalk::{FileType, GlobWalkerBuilder};
+
+use crate::settings::Settings;
+
+pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) {
+    let walker = GlobWalkerBuilder::new(base, pattern)
+        .case_insensitive(true)
+        .file_type(FileType::FILE)
+        .build()
+        .unwrap();
+
+    for file in walker {
+        let file = file.unwrap();
+        let path = file.path();
+
+        let mut settings = Settings::clone_current();
+        settings.set_input_file(&path);
+        settings.set_snapshot_suffix(path.file_name().unwrap().to_str().unwrap());
+
+        settings.bind(|| {
+            f(path);
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@
 //!
 //! * `diff` (default): prints the diffs
 //! * `summary`: prints only summaries (name of snapshot files etc.)
-//! * `mimimal`: like `summary` but more minimal
+//! * `minimal`: like `summary` but more minimal
 //! * `none`: insta will not output any extra information
 //!
 //! # Redactions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,31 @@
 //! });
 //! ```
 //!
+//! # Globbing
+//!
+//! **Feature:** `glob`
+//!
+//! Sometimes it can be useful to run code against multiple input files.
+//! The easiest way to accomplish this is to use the `glob!` macro which
+//! runs a closure for each input file that matches.  Before the closure
+//! is executed the settings are updated to set a reference to the input
+//! file and the appropriate snapshot suffix.
+//!
+//! Example:
+//!
+//! ```rust,ignore
+//! use std::fs;
+//!
+//! glob!("inputs/*.txt", |path| {
+//!     let input = fs::read_to_string(path).unwrap();
+//!     assert_json_snapshot!(input.to_uppercase());
+//! });
+//! ```
+//!
+//! The path to the glob macro is relative to the location of the test
+//! file.  It uses the [`globset`](https://crates.io/crates/globset) crate
+//! for actual glob operations.
+//!
 //! # Inline Snapshots
 //!
 //! Additionally snapshots can also be stored inline.  In that case the format
@@ -334,6 +359,9 @@ mod legacy_macros;
 #[cfg(feature = "redactions")]
 mod redaction;
 
+#[cfg(feature = "glob")]
+mod glob;
+
 #[cfg(test)]
 mod test;
 
@@ -371,6 +399,9 @@ pub mod _macro_support {
     pub use crate::content::Content;
     pub use crate::runtime::{assert_snapshot, AutoName, ReferenceValue};
     pub use crate::serialization::{serialize_value, SerializationFormat, SnapshotLocation};
+
+    #[cfg(feature = "glob")]
+    pub use crate::glob::glob_exec;
 
     #[cfg(feature = "redactions")]
     pub use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@
 //!
 //! * `ron`: enables RON support (`assert_ron_snapshot!`)
 //! * `redactions`: enables support for redactions
+//! * `glob`: enables support for globbing (`glob!`)
 //!
 //! # Settings
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -333,3 +333,20 @@ macro_rules! with_settings {
         settings.bind(|| $body)
     }}
 }
+
+/// Executes a closure for all input files matching a glob.
+///
+/// The closure is passed the path to the file.
+#[cfg(feature = "glob")]
+#[macro_export]
+macro_rules! glob {
+    ($glob:expr, $closure:expr) => {{
+        let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join(file!())
+            .parent()
+            .unwrap()
+            .canonicalize()
+            .unwrap();
+        $crate::_macro_support::glob_exec(&base, $glob, $closure);
+    }};
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -66,7 +66,7 @@ pub struct ActualSettings {
 /// ```rust,ignore
 /// use insta;
 ///
-/// let mut settings = insta::Settings::new();
+/// let mut settings = insta::Settings::clone_current();
 /// settings.set_sort_maps(true);
 /// settings.bind(|| {
 ///     insta::assert_snapshot!(...);
@@ -87,6 +87,9 @@ impl Default for Settings {
 
 impl Settings {
     /// Returns the default settings.
+    ///
+    /// It's recommended to use `clone_current` instead so that
+    /// already applied modifications are not discarded.
     pub fn new() -> Settings {
         Settings::default()
     }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -76,6 +76,9 @@ pub struct MetaData {
     /// Optionally the expression that created the snapshot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) expression: Option<String>,
+    /// Reference to the input file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) input_file: Option<String>,
 }
 
 impl MetaData {
@@ -98,6 +101,11 @@ impl MetaData {
                 .and_then(|s| s.strip_prefix(base).ok().map(|x| x.to_path_buf()))
                 .unwrap_or_else(|| base.to_path_buf())
         })
+    }
+
+    /// Returns the input file reference.
+    pub fn input_file(&self) -> Option<&str> {
+        self.input_file.as_deref()
     }
 }
 

--- a/tests/inputs/hello.txt
+++ b/tests/inputs/hello.txt
@@ -1,0 +1,1 @@
+Contents of hello

--- a/tests/snapshots/test_suffixes__basic_globbing@hello.txt.snap
+++ b/tests/snapshots/test_suffixes__basic_globbing@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_suffixes.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/snapshots/test_suffixes__basic_suffixes@1.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@1.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_suffixes.rs
+expression: "&value"
+---
+1

--- a/tests/snapshots/test_suffixes__basic_suffixes@2.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@2.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_suffixes.rs
+expression: "&value"
+---
+2

--- a/tests/snapshots/test_suffixes__basic_suffixes@3.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@3.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_suffixes.rs
+expression: "&value"
+---
+3

--- a/tests/test_suffixes.rs
+++ b/tests/test_suffixes.rs
@@ -1,0 +1,17 @@
+#[test]
+fn test_basic_suffixes() {
+    for value in vec![1, 2, 3] {
+        insta::with_settings!({snapshot_suffix => value.to_string()}, {
+            insta::assert_json_snapshot!(&value);
+        });
+    }
+}
+
+#[cfg(feature = "glob")]
+#[test]
+fn test_basic_globbing() {
+    insta::glob!("inputs/*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_json_snapshot!(&contents);
+    });
+}


### PR DESCRIPTION
This is another attempt of implementing globbing. Replaces #109

The motivation here is that the glob support is just a thin wrapper around an expanded snapshot naming system. You can now set suffixes for snapshot names and reference files for the meta data independent of the `glob!` macro so users can use something other than globbing if wanted.