### PR TITLE
Fix insta::glob! in workspaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,7 +391,7 @@ pub use crate::redaction::dynamic_redaction;
 #[doc(hidden)]
 pub mod _macro_support {
     pub use crate::content::Content;
-    pub use crate::runtime::{assert_snapshot, AutoName, ReferenceValue};
+    pub use crate::runtime::{assert_snapshot, get_cargo_workspace, AutoName, ReferenceValue};
     pub use crate::serialization::{serialize_value, SerializationFormat, SnapshotLocation};
 
     #[cfg(feature = "glob")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -341,12 +341,12 @@ macro_rules! with_settings {
 #[macro_export]
 macro_rules! glob {
     ($glob:expr, $closure:expr) => {{
-        let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        let base = $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
             .join(file!())
             .parent()
             .unwrap()
             .canonicalize()
-            .unwrap();
+            .unwrap_or_else(|e| panic!("failed to canonicalize insta::glob! base path: {}", e));
         $crate::_macro_support::glob_exec(&base, $glob, $closure);
     }};
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -149,7 +149,7 @@ fn get_cargo() -> String {
         .unwrap_or_else(|| "cargo".to_string())
 }
 
-fn get_cargo_workspace(manifest_dir: &str) -> &Path {
+pub fn get_cargo_workspace(manifest_dir: &str) -> &Path {
     // we really do not care about poisoning here.
     let mut workspaces = WORKSPACES.lock().unwrap_or_else(|x| x.into_inner());
     if let Some(rv) = workspaces.get(manifest_dir) {


### PR DESCRIPTION
Uses the already existing infrastructure to find the cargo manifest directory. Fixes #119.