### PR TITLE
Chore: bump deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ serialization = []
 difference = "2.0.0"
 serde = { version = "1.0.85", features = ["derive"] }
 serde_yaml = "0.8.8"
-console = { version = "0.10.0", default-features = false }
+console = { version = "0.11.0", default-features = false }
 serde_json = "1.0.36"
 lazy_static = "1.4.0"
 pest = { version = "2.1.0", optional = true }

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 insta = { version = "0.16.0", path = "..", features = ["redactions"] }
-console = "0.10.0"
+console = "0.11.0"
 clap = "2.33.0"
 difference = "2.0.0"
 structopt = "0.3.3"


### PR DESCRIPTION
`console` to `0.11.0`