### PR TITLE
Typo'd globs should cause tests to fail

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -4,14 +4,16 @@ use globwalk::{FileType, GlobWalkerBuilder};
 
 use crate::settings::Settings;
 
-pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) {
+pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) -> usize {
     let walker = GlobWalkerBuilder::new(base, pattern)
         .case_insensitive(true)
         .file_type(FileType::FILE)
         .build()
         .unwrap();
 
+    let mut count = 0;
     for file in walker {
+        count += 1;
         let file = file.unwrap();
         let path = file.path();
 
@@ -23,4 +25,6 @@ pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) {
             f(path);
         });
     }
+
+    count
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -347,6 +347,7 @@ macro_rules! glob {
             .unwrap()
             .canonicalize()
             .unwrap_or_else(|e| panic!("failed to canonicalize insta::glob! base path: {}", e));
-        $crate::_macro_support::glob_exec(&base, $glob, $closure);
+        let count = $crate::_macro_support::glob_exec(&base, $glob, $closure);
+        assert!(count > 0, "the glob \"{}\" did not match anything", $glob);
     }};
 }

--- a/tests/inputs/goodbye.txt
+++ b/tests/inputs/goodbye.txt
@@ -1,0 +1,1 @@
+Contents of goodbye

--- a/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_glob.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/test_suffixes.rs
+source: tests/test_glob.rs
 expression: "&contents"
 input_file: tests/inputs/hello.txt
 ---

--- a/tests/test_glob.rs
+++ b/tests/test_glob.rs
@@ -9,8 +9,8 @@ fn test_basic_globbing() {
 }
 
 #[test]
-fn test_that_should_probably_fail() {
-    // FIXME: Ideally this would fail.
+#[should_panic(expected = "the glob \"inputz/*.txt\" did not match anything")]
+fn test_glob_must_have_matches() {
     let typod_glob = "inputz/*.txt";
     insta::glob!(typod_glob, |_| assert!(false));
 }

--- a/tests/test_glob.rs
+++ b/tests/test_glob.rs
@@ -1,0 +1,9 @@
+#![cfg(feature = "glob")]
+
+#[test]
+fn test_basic_globbing() {
+    insta::glob!("inputs/*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_json_snapshot!(&contents);
+    });
+}

--- a/tests/test_glob.rs
+++ b/tests/test_glob.rs
@@ -7,3 +7,10 @@ fn test_basic_globbing() {
         insta::assert_json_snapshot!(&contents);
     });
 }
+
+#[test]
+fn test_that_should_probably_fail() {
+    // FIXME: Ideally this would fail.
+    let typod_glob = "inputz/*.txt";
+    insta::glob!(typod_glob, |_| assert!(false));
+}

--- a/tests/test_suffixes.rs
+++ b/tests/test_suffixes.rs
@@ -6,12 +6,3 @@ fn test_basic_suffixes() {
         });
     }
 }
-
-#[cfg(feature = "glob")]
-#[test]
-fn test_basic_globbing() {
-    insta::glob!("inputs/*.txt", |path| {
-        let contents = std::fs::read_to_string(path).unwrap();
-        insta::assert_json_snapshot!(&contents);
-    });
-}


### PR DESCRIPTION
I got caught off guard by this; my tests were passing when I thought they should fail, and it took me longer than it should have to realize that was because my glob was wrong, therefore it wasn't matching anything, therefore my closure was never being invoked.

What are your thoughts on asserting that globs always match at least one file?

---

Thanks for publishing this amazingly-useful library, by the way! 🙌 