### PR TITLE
Add CSV support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ glob = ["globwalk"]
 serialization = []
 
 [dependencies]
+csv = { version = "1.1.3", optional = true }
 difference = "2.0.0"
 serde = { version = "1.0.85", features = ["derive"] }
 serde_yaml = "0.8.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@
 //! - `assert_snapshot!` for comparing basic string snapshots.
 //! - `assert_debug_snapshot!` for comparing `Debug` outputs of values.
 //! - `assert_display_snapshot!` for comparing `Display` outputs of values.
+//! - `aasert_csv_snapshot!` for comparing CSV serialized output of
+//!   types implementing `serde::Serialize`. (requires the `csv` feature)
 //! - `assert_yaml_snapshot!` for comparing YAML serialized
 //!   output of types implementing `serde::Serialize`.
 //! - `assert_ron_snapshot!` for comparing RON serialized output of
@@ -322,6 +324,7 @@
 //!
 //! The following features exist:
 //!
+//! * `csv`: enables CSV support (`assert_csv_snapshot!`)
 //! * `ron`: enables RON support (`assert_ron_snapshot!`)
 //! * `redactions`: enables support for redactions
 //! * `glob`: enables support for globbing (`glob!`)

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,46 @@
+/// Asserts a `Serialize` snapshot in CSV format.
+///
+/// **Feature:** `csv` (disabled by default)
+///
+/// This works exactly like [`assert_yaml_snapshot`](macro.assert_yaml_snapshot.html)
+/// but serializes in [CSV](https://github.com/burntsushi/rust-csv) format instead of
+/// YAML.
+///
+/// Example:
+///
+/// ```no_run,ignore
+/// assert_csv_snapshot!(vec[1, 2, 3]);
+/// ```
+///
+/// The third argument to the macro can be an object expression for redaction.
+/// It's in the form `{ selector => replacement }`.  For more information
+/// about redactions see [redactions](index.html#redactions).
+///
+/// The snapshot name is optional but can be provided as first argument.
+/// For more information see [named snapshots](index.html#named-snapshots)
+#[cfg(feature = "csv")]
+#[macro_export]
+macro_rules! assert_csv_snapshot {
+    ($value:expr, @$snapshot:literal) => {{
+        $crate::_assert_serialized_snapshot!($value, Csv, @$snapshot);
+    }};
+    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+        $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Csv, @$snapshot);
+    }};
+    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+        $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Csv);
+    }};
+    ($name:expr, $value:expr) => {{
+        $crate::_assert_serialized_snapshot!(Some($name), $value, Csv);
+    }};
+    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+        $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Csv);
+    }};
+    ($value:expr) => {{
+        $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, Csv);
+    }};
+}
+
 /// Asserts a `Serialize` snapshot in YAML format.
 ///
 /// The value needs to implement the `serde::Serialize` trait and the snapshot

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -5,6 +5,8 @@ use crate::content::{Content, ContentSerializer};
 use crate::settings::Settings;
 
 pub enum SerializationFormat {
+    #[cfg(feature = "csv")]
+    Csv,
     #[cfg(feature = "ron")]
     Ron,
     Yaml,
@@ -43,6 +45,16 @@ pub fn serialize_content(
             }
         }
         SerializationFormat::Json => serde_json::to_string_pretty(&content).unwrap(),
+        #[cfg(feature = "csv")]
+        SerializationFormat::Csv => {
+            let mut buf = Vec::with_capacity(128);
+            {
+                let mut writer = csv::Writer::from_writer(&mut buf);
+                writer.serialize(&content).unwrap();
+                writer.flush().unwrap();
+            }
+            String::from_utf8(buf).unwrap()
+        }
         #[cfg(feature = "ron")]
         SerializationFormat::Ron => {
             let mut serializer = ron::ser::Serializer::new(

--- a/tests/snapshots/test_redaction__user_csv.snap
+++ b/tests/snapshots/test_redaction__user_csv.snap
@@ -1,0 +1,7 @@
+---
+source: tests/test_redaction.rs
+expression: "&User{id: 44,\n      username: \"julius_csv\".to_string(),\n      email: Email(\"julius@example.com\".to_string()),\n      extra: \"\".to_string(),}"
+---
+id,username,email,extra
+[id],julius_csv,julius@example.com,
+

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "csv")]
+use insta::assert_csv_snapshot;
 #[cfg(feature = "ron")]
 use insta::assert_ron_snapshot;
 use insta::{assert_debug_snapshot, assert_json_snapshot, assert_snapshot, assert_yaml_snapshot};
@@ -46,6 +48,29 @@ fn test_newline() {
     // https://github.com/mitsuhiko/insta/issues/39
     assert_snapshot!("\n", @"
 ");
+}
+
+#[cfg(feature = "csv")]
+#[test]
+fn test_csv_inline() {
+    #[derive(Serialize)]
+    pub struct Email(String);
+
+    #[derive(Serialize)]
+    pub struct User {
+        id: u32,
+        username: String,
+        email: Email,
+    }
+
+    assert_csv_snapshot!(User {
+        id: 1453,
+        username: "mehmed-doe".into(),
+        email: Email("mehmed@doe.invalid".into()),
+    }, @r###"
+    id,username,email
+    1453,mehmed-doe,mehmed@doe.invalid
+    "###);
 }
 
 #[cfg(feature = "ron")]

--- a/tests/test_redaction.rs
+++ b/tests/test_redaction.rs
@@ -74,6 +74,20 @@ fn test_with_random_value_and_trailing_comma() {
     });
 }
 
+#[cfg(feature = "csv")]
+#[test]
+fn test_with_random_value_csv() {
+    use insta::assert_csv_snapshot;
+    assert_csv_snapshot!("user_csv", &User {
+        id: 44,
+        username: "julius_csv".to_string(),
+        email: Email("julius@example.com".to_string()),
+        extra: "".to_string(),
+    }, {
+        ".id" => "[id]"
+    });
+}
+
 #[cfg(feature = "ron")]
 #[test]
 fn test_with_random_value_ron() {


### PR DESCRIPTION
Hey! Thanks for the amazing library.

I needed to be able to perform redactions on CSV representations of serialized objects, so added an `assert_csv_snapshot` macro.

The PR follows the rest of the repo wrt to the `csv` dependency and associated macro being optional.