### PR TITLE
When applying inline snapshot, generate prefix/suffix using char offsets

### DIFF
--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -75,8 +75,8 @@ impl FilePatcher {
         let inline = &mut self.inline_snapshots[id];
 
         // find prefix and suffix on the first and last lines
-        let prefix = self.lines[inline.start.0][..inline.start.1].to_string();
-        let suffix = self.lines[inline.end.0][inline.end.1..].to_string();
+        let prefix: String = self.lines[inline.start.0].chars().take(inline.start.1).collect();
+        let suffix: String = self.lines[inline.end.0].chars().skip(inline.end.1).collect();
 
         // replace lines
         let snapshot_line_contents =


### PR DESCRIPTION
Fixes #137 

Previously the columns delimiting the replacement were being interpreted as byte offsets into their lines, rather than char offsets. This fix just updates the prefix/suffix construction to use a `chars` iterator.

I wasn't sure on how/where to add tests for this, as this code is only run as part of `cargo-insta`, and the existing tests seem to only check the snapshot generation/equivalency, rather than inline application.

Supporting are two action runs, before and after this change:

- before: https://github.com/c-spencer/insta-unicode-repro/actions/runs/351125741
- after: https://github.com/c-spencer/insta-unicode-repro/actions/runs/351158192

I've also tested locally on that repository and the patch is applied correctly (i.e. without duplicated parts of the previous snapshot in the suffix, as was happening for me and as described in #42 previously).