### PR TITLE
fix reference to "assert_yaml_snapshot" in "assert_toml_snapshot" docs

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -45,7 +45,7 @@ macro_rules! assert_csv_snapshot {
 ///
 /// **Feature:** `toml` (disabled by default)
 ///
-/// This works exactly like [`assert_toml_snapshot!`]
+/// This works exactly like [`assert_yaml_snapshot!`]
 /// but serializes in [TOML](https://github.com/alexcrichton/toml-rs) format instead of
 /// YAML.  Note that TOML cannot represent all values due to limitations in the
 /// format.


### PR DESCRIPTION
It looks like this docstring was intended to refer to the _yaml_ macro rather than a self-reference to the _toml_ version.