### PR TITLE
Experimental inline snapshot highlighting for vscode

### DIFF
--- a/vscode-insta/language-configuration.json
+++ b/vscode-insta/language-configuration.json
@@ -1,9 +1,6 @@
 {
     "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#"
     },
     // symbols used as brackets
     "brackets": [

--- a/vscode-insta/package.json
+++ b/vscode-insta/package.json
@@ -39,6 +39,16 @@
         "language": "insta-snapshots",
         "scopeName": "source.insta-snapshots",
         "path": "./syntaxes/insta-snapshots.tmLanguage.json"
+      },
+      {
+        "scopeName": "source.inline-insta-snapshots",
+        "injectTo": [
+          "source.rust"
+        ],
+        "path": "./syntaxes/inline-insta-snapshots.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.inline-insta-snapshot": "insta-snapshots"
+        }
       }
     ]
   }

--- a/vscode-insta/syntaxes/inline-insta-snapshots.tmLanguage.json
+++ b/vscode-insta/syntaxes/inline-insta-snapshots.tmLanguage.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "injectionSelector": "L:source -string -comment",
+  "fileTypes": [
+    "rust"
+  ],
+  "patterns": [
+    {
+      "begin": "(@)(r###)(\")",
+      "contentName": "meta.embedded.inline-insta-snapshot",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.operator.subpattern.rust"
+        },
+        "2": {
+          "name": "punctuation.definition.string.raw.rust"
+        },
+        "3": {
+          "name": "punctuation.definition.string.rust"
+        }
+      },
+      "end": "(\")(###)",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.rust"
+        },
+        "2": {
+          "name": "punctuation.definition.string.raw.rust"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.insta-snapshots#snapshot"
+        }
+      ]
+    }
+  ],
+  "scopeName": "source.inline-insta-snapshots"
+}


### PR DESCRIPTION
Unfortunately runs into issues with semantic tokens but in theory this highlights inline snapshots.