### PR TITLE
Fix glob not working and fail if it does not return matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.5.1
+
+* Fixed glob not working correctly.
+* Fail by default if glob is not returning any matches. Fixes #151.
+
 ## 1.5.0
 
 * Add `pending-snapshots` parameter to `cargo-insta`.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -21,6 +21,8 @@ lazy_static! {
         prepend_module_to_snapshot: true,
         #[cfg(feature = "redactions")]
         redactions: Redactions::default(),
+        #[cfg(feature = "glob")]
+        allow_empty_glob: false,
     });
 }
 thread_local!(static CURRENT_SETTINGS: RefCell<Settings> = RefCell::new(Settings::new()));
@@ -52,6 +54,8 @@ pub struct ActualSettings {
     pub prepend_module_to_snapshot: bool,
     #[cfg(feature = "redactions")]
     pub redactions: Redactions,
+    #[cfg(feature = "glob")]
+    pub allow_empty_glob: bool,
 }
 
 /// Configures how insta operates at test time.
@@ -125,7 +129,7 @@ impl Settings {
         self.inner.sort_maps
     }
 
-    /// Disbales prepending of modules to the snapshot filename.
+    /// Disables prepending of modules to the snapshot filename.
     ///
     /// By default the filename of a snapshot is `<module>__<name>.snap`.
     /// Setting this flag to `false` changes the snapshot filename to just
@@ -139,6 +143,24 @@ impl Settings {
     /// Returns the current value for module name prepending.
     pub fn prepend_module_to_snapshot(&self) -> bool {
         self.inner.prepend_module_to_snapshot
+    }
+
+    /// Allows the `glob!` macro to succeed if it matches no files.
+    ///
+    /// By default the glob macro will fail the test if it does not find
+    /// any files to prevent accidental typos.  This can be disabled when
+    /// fixtures should be conditional.
+    ///
+    /// The default value is `false`.
+    #[cfg(feature = "glob")]
+    pub fn set_allow_empty_glob(&mut self, value: bool) {
+        self._private_inner_mut().allow_empty_glob = value;
+    }
+
+    /// Returns the current value for the empty glob setting.
+    #[cfg(feature = "glob")]
+    pub fn allow_empty_glob(&self) -> bool {
+        self.inner.allow_empty_glob
     }
 
     /// Sets the snapshot suffix.

--- a/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_glob.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_glob.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/snapshots/test_glob__globs_follow_links@goodbye.txt.snap
+++ b/tests/snapshots/test_glob__globs_follow_links@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_glob.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/snapshots/test_glob__globs_follow_links@hello.txt.snap
+++ b/tests/snapshots/test_glob__globs_follow_links@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_glob.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/test_glob.rs
+++ b/tests/test_glob.rs
@@ -15,3 +15,11 @@ fn test_globs_follow_links() {
         insta::assert_json_snapshot!(&contents);
     });
 }
+
+#[test]
+#[should_panic(expected = "the glob! macro did not match any files.")]
+fn test_empty_glob_fails() {
+    insta::glob!("nonexistent", |_| {
+        // nothing
+    });
+}


### PR DESCRIPTION
There was a regression that broke glob not working correctly. This now also changes it so that empty globs fail by default.

Fixes #151.