### PR TITLE
Change CSV serialization format to support multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.6.0
+
+* Change CSV serialization format to format multiple structs as
+  multiple rows.   Fixes #156
+
 ## 1.5.3
 
 * Replace [difference](https://crates.io/crates/difference) with

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -52,8 +52,19 @@ pub fn serialize_content(
             let mut buf = Vec::with_capacity(128);
             {
                 let mut writer = csv::Writer::from_writer(&mut buf);
-                writer.serialize(&content).unwrap();
+                // if the top-level content we're serializing is a vector we
+                // want to serialize it multiple times once for each item.
+                if let Some(content_slice) = content.as_slice() {
+                    for content in content_slice {
+                        writer.serialize(content).unwrap();
+                    }
+                } else {
+                    writer.serialize(&content).unwrap();
+                }
                 writer.flush().unwrap();
+            }
+            if buf.ends_with(b"\n") {
+                buf.truncate(buf.len() - 1);
             }
             String::from_utf8(buf).unwrap()
         }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -75,6 +75,37 @@ fn test_csv_inline() {
     "###);
 }
 
+#[cfg(feature = "csv")]
+#[test]
+fn test_csv_inline_multiple_values() {
+    #[derive(Serialize)]
+    pub struct Email(String);
+
+    #[derive(Serialize)]
+    pub struct User {
+        id: u32,
+        username: String,
+        email: Email,
+    }
+
+    let user1 = User {
+        id: 1453,
+        username: "mehmed-doe".into(),
+        email: Email("mehmed@doe.invalid".into()),
+    };
+    let user2 = User {
+        id: 1455,
+        username: "mehmed-doe-di".into(),
+        email: Email("mehmed@doe-di.invalid".into()),
+    };
+
+    assert_csv_snapshot!(vec![user1, user2], @r###"
+    id,username,email
+    1453,mehmed-doe,mehmed@doe.invalid
+    1455,mehmed-doe-di,mehmed@doe-di.invalid
+    "###);
+}
+
 #[cfg(feature = "ron")]
 #[test]
 fn test_ron_inline() {


### PR DESCRIPTION
This changes the CSV serialization format to support multiple values toplevel.

This is technically a breaking change but because the existing format is so useless I think it's fair to assume that nobody would be using this feature in the current form.

Fixes #156