### PR TITLE
Update similar to 1.2.0 and enable inline highlighting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,4 @@ toml = { version = "0.5.7", optional = true }
 globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 uuid = "0.8.1"
-similar = "1.1.0"
+similar = { version = "1.2.0", features = ["inline"] }

--- a/cargo-insta/Cargo.lock
+++ b/cargo-insta/Cargo.lock
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da916d7c5876bff6fbf5794bd1e64aba8f5f110b76b192d80bb264423c0736f6"
+checksum = "e8a1695d0e5662b51d217ec76c88e7b546f0e68d7fc10856b7b82a23c772d96c"
 
 [[package]]
 name = "strsim"


### PR DESCRIPTION
I will bump this further to 1.3.0 after making similar compatible with older rust versions. See #161 