### PR TITLE
Fix empty lines confusing inline snapshots

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -632,7 +632,7 @@ fn min_indentation(snapshot: &str) -> usize {
     }
 
     lines
-        .skip_while(|l| l.is_empty())
+        .filter(|l| !l.is_empty())
         .map(count_leading_spaces)
         .min()
         .unwrap_or(0)
@@ -699,7 +699,7 @@ fn normalize_inline_snapshot(snapshot: &str) -> String {
         .trim_end()
         .lines()
         .skip_while(|l| l.is_empty())
-        .map(|l| &l[indentation..])
+        .map(|l| l.get(indentation..).unwrap_or(""))
         .collect::<Vec<&str>>()
         .join("\n")
 }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -215,3 +215,14 @@ fn test_yaml_inline_redacted() {
 fn test_non_basic_plane() {
     assert_snapshot!("a 😀oeu", @"a 😀oeu");
 }
+
+#[test]
+fn test_multiline_with_empty_lines() {
+    assert_snapshot!("# first\nsecond\n  third\n\n# alternative", @r###"
+    # first
+    second
+      third
+
+    # alternative
+    "###);
+}


### PR DESCRIPTION
Insta could end up producing bad inline snapshots when empty lines were involved.

Refs #117