### PR TITLE
Normalize newlines before comparision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.7.0
 
 * Added support for u128/i128.  (#169)
+* Normalize newlines to unix before before asserting.  (#172)
 
 ## 1.6.3
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -566,6 +566,8 @@ fn generate_snapshot_name_for_thread(module_path: &str) -> Result<String, &'stat
 /// frozen value string.  If the string starts with the '⋮' character
 /// (optionally prefixed by whitespace) the alternative serialization format
 /// is picked which has slightly improved indentation semantics.
+///
+/// This also changes all newlines to \n
 pub(super) fn get_inline_snapshot_value(frozen_value: &str) -> String {
     // TODO: could move this into the SnapshotContents `from_inline` method
     // (the only call site)
@@ -693,6 +695,7 @@ a
 }
 
 // Removes excess indentation, removes excess whitespace at start & end
+// and changes newlines to \n.
 fn normalize_inline_snapshot(snapshot: &str) -> String {
     let indentation = min_indentation(snapshot);
     snapshot
@@ -924,6 +927,7 @@ pub fn assert_snapshot(
     };
 
     let new_snapshot_contents: SnapshotContents = new_snapshot.into();
+
     let new = Snapshot::from_components(
         module_path.replace("::", "__"),
         snapshot_name.as_ref().map(|x| x.to_string()),
@@ -952,7 +956,7 @@ pub fn assert_snapshot(
 
     // if the snapshot matches we're done.
     if let Some(ref old_snapshot) = old {
-        if old_snapshot.contents() == new.contents() {
+        if dbg!(old_snapshot.contents()) == dbg!(new.contents()) {
             // let's just make sure there are no more pending files lingering
             // around.
             if let Some(ref snapshot_file) = snapshot_file {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -269,6 +269,7 @@ impl SnapshotContents {
     pub fn from_inline(value: &str) -> SnapshotContents {
         SnapshotContents(get_inline_snapshot_value(value))
     }
+
     pub fn to_inline(&self, indentation: usize) -> String {
         let contents = &self.0;
         let mut out = String::new();
@@ -306,13 +307,15 @@ impl SnapshotContents {
 
 impl From<&str> for SnapshotContents {
     fn from(value: &str) -> SnapshotContents {
-        SnapshotContents(value.to_string())
+        // make sure we have unix newlines consistently
+        SnapshotContents(value.replace("\r\n", "\n").to_string())
     }
 }
 
 impl From<String> for SnapshotContents {
     fn from(value: String) -> SnapshotContents {
-        SnapshotContents(value)
+        // make sure we have unix newlines consistently
+        SnapshotContents(value.replace("\r\n", "\n").to_string())
     }
 }
 

--- a/tests/snapshots/test_bugs__crlf.snap
+++ b/tests/snapshots/test_bugs__crlf.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_bugs.rs
+expression: "\"foo\\r\\nbar\\r\\nbaz\""
+
+---
+foo
+bar
+baz

--- a/tests/snapshots/test_bugs__trailing_crlf.snap
+++ b/tests/snapshots/test_bugs__trailing_crlf.snap
@@ -1,0 +1,9 @@
+---
+source: tests/test_bugs.rs
+expression: "\"foo\\r\\nbar\\r\\nbaz\\r\\n\""
+
+---
+foo
+bar
+baz
+

--- a/tests/test_bugs.rs
+++ b/tests/test_bugs.rs
@@ -1,0 +1,18 @@
+#[test]
+fn test_crlf() {
+    insta::assert_snapshot!("foo\r\nbar\r\nbaz");
+}
+
+#[test]
+fn test_trailing_crlf() {
+    insta::assert_snapshot!("foo\r\nbar\r\nbaz\r\n");
+}
+
+#[test]
+fn test_trailing_crlf_inline() {
+    insta::assert_snapshot!("foo\r\nbar\r\nbaz\r\n", @r###"
+    foo
+    bar
+    baz
+    "###);
+}


### PR DESCRIPTION
Before if you used windows newlines instead of unix newlines snapshots would always
mismatch because they were inconsistently normalized.

Fixes #171