### PR TITLE
[Doc] Entry link to ApprovalTests community

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-Snapshots tests (also sometimes called approval tests) are tests that
+Snapshots tests (also sometimes called [approval tests](https://approvaltests.com/)) are tests that
 assert values against a reference value (the snapshot). This is similar
 to how `assert_eq!` lets you compare a value against a reference value but
 unlike simple string assertions, snapshot tests let you test against complex


### PR DESCRIPTION
What:
A link to the Approval Tests umbrella website.
Why:
Helps Rust developers  tap into wider community and accumulated lessons learned.
How:
Add a link to approvaltests.com