### PR TITLE
Rustfmt at snapshot time rather than display time

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,9 @@ pub use crate::redaction::dynamic_redaction;
 #[doc(hidden)]
 pub mod _macro_support {
     pub use crate::content::Content;
-    pub use crate::runtime::{assert_snapshot, get_cargo_workspace, AutoName, ReferenceValue};
+    pub use crate::runtime::{
+        assert_snapshot, format_rust_expression, get_cargo_workspace, AutoName, ReferenceValue,
+    };
     pub use crate::serialization::{serialize_value, SerializationFormat, SnapshotLocation};
 
     #[cfg(feature = "glob")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,8 @@ mod redaction;
 #[cfg(feature = "glob")]
 mod glob;
 
+mod loader;
+
 #[cfg(test)]
 mod test;
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,101 @@
+use std::error::Error;
+use std::ffi::OsStr;
+use std::io::{self, BufRead};
+
+use crate::{MetaData, Snapshot};
+
+pub(crate) trait SnapfileFormatter {
+    fn serialize(snapshot: &Snapshot, f: &mut dyn io::Write) -> Result<(), Box<dyn Error>>;
+    fn deserialize(f: &mut dyn BufRead, fname: &OsStr) -> Result<Snapshot, Box<dyn Error>>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefaultSnapfileFormatter;
+
+impl SnapfileFormatter for DefaultSnapfileFormatter {
+    fn serialize(snapshot: &Snapshot, mut f: &mut dyn io::Write) -> Result<(), Box<dyn Error>> {
+        serde_yaml::to_writer(&mut f, &snapshot.metadata)?;
+        f.write_all(b"\n---\n")?;
+        f.write_all(snapshot.contents_str().as_bytes())?;
+        f.write_all(b"\n")?;
+        Ok(())
+    }
+
+    fn deserialize(mut f: &mut dyn BufRead, fname: &OsStr) -> Result<Snapshot, Box<dyn Error>> {
+        let mut buf = String::new();
+
+        f.read_line(&mut buf)?;
+
+        // yaml format
+        let metadata = if buf.trim_end() == "---" {
+            loop {
+                let read = f.read_line(&mut buf)?;
+                if read == 0 {
+                    break;
+                }
+                if buf[buf.len() - read..].trim_end() == "---" {
+                    buf.truncate(buf.len() - read);
+                    break;
+                }
+            }
+            serde_yaml::from_str(&buf)?
+        // legacy format
+        } else {
+            let mut rv = MetaData::default();
+            loop {
+                buf.clear();
+                let read = f.read_line(&mut buf)?;
+                if read == 0 || buf.trim_end().is_empty() {
+                    buf.truncate(buf.len() - read);
+                    break;
+                }
+                let mut iter = buf.splitn(2, ':');
+                if let Some(key) = iter.next() {
+                    if let Some(value) = iter.next() {
+                        let value = value.trim();
+                        match key.to_lowercase().as_str() {
+                            "expression" => rv.expression = Some(value.to_string()),
+                            "source" => rv.source = Some(value.into()),
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            rv
+        };
+
+        buf.clear();
+        for (idx, line) in (&mut f).lines().enumerate() {
+            let line = line?;
+            if idx > 0 {
+                buf.push('\n');
+            }
+            buf.push_str(&line);
+        }
+
+        let module_name = fname
+            .to_str()
+            .unwrap_or("")
+            .split("__")
+            .next()
+            .unwrap_or("<unknown>")
+            .to_string();
+
+        let snapshot_name = fname
+            .to_str()
+            .unwrap_or("")
+            .split('.')
+            .next()
+            .unwrap_or("")
+            .splitn(2, "__")
+            .nth(1)
+            .map(|x| x.to_string());
+
+        Ok(Snapshot::from_components(
+            module_name,
+            snapshot_name,
+            metadata,
+            buf.into(),
+        ))
+    }
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,10 @@
+#[macro_export]
+macro_rules! _insta_rustfmt_stringify {
+    ($($tt:tt)*) => {
+        &$crate::_macro_support::format_rust_expression(stringify!($($tt)*))
+    };
+}
+
 /// Asserts a `Serialize` snapshot in CSV format.
 ///
 /// **Feature:** `csv` (disabled by default)
@@ -241,13 +248,13 @@ macro_rules! _assert_serialized_snapshot {
         );
         $crate::assert_snapshot!(
             value,
-            stringify!($value),
+            $crate::_insta_rustfmt_stringify!($value),
             @$snapshot
         );
     }};
     ($value:expr, {$($k:expr => $v:expr),*$(,)?}, $format:ident, @$snapshot:literal) => {{
         let (vec, value) = $crate::_prepare_snapshot_for_redaction!($value, {$($k => $v),*}, $format, Inline);
-        $crate::assert_snapshot!(value, stringify!($value), @$snapshot);
+        $crate::assert_snapshot!(value, $crate::_insta_rustfmt_stringify!($value), @$snapshot);
     }};
     ($name:expr, $value:expr, $format:ident) => {{
         let value = $crate::_macro_support::serialize_value(
@@ -258,12 +265,12 @@ macro_rules! _assert_serialized_snapshot {
         $crate::assert_snapshot!(
             $name,
             value,
-            stringify!($value)
+            $crate::_insta_rustfmt_stringify!($value)
         );
     }};
     ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}, $format:ident) => {{
         let (vec, value) = $crate::_prepare_snapshot_for_redaction!($value, {$($k => $v),*}, $format, File);
-        $crate::assert_snapshot!($name, value, stringify!($value));
+        $crate::assert_snapshot!($name, value, $crate::_insta_rustfmt_stringify!($value));
     }}
 }
 
@@ -310,15 +317,15 @@ macro_rules! _prepare_snapshot_for_redaction {
 macro_rules! assert_debug_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         let value = format!("{:#?}", $value);
-        $crate::assert_snapshot!(value, stringify!($value), @$snapshot);
+        $crate::assert_snapshot!(value, $crate::_insta_rustfmt_stringify!($value), @$snapshot);
     }};
     ($name:expr, $value:expr) => {{
         let value = format!("{:#?}", $value);
-        $crate::assert_snapshot!(Some($name), value, stringify!($value));
+        $crate::assert_snapshot!(Some($name), value, $crate::_insta_rustfmt_stringify!($value));
     }};
     ($value:expr) => {{
         let value = format!("{:#?}", $value);
-        $crate::assert_snapshot!($crate::_macro_support::AutoName, value, stringify!($value));
+        $crate::assert_snapshot!($crate::_macro_support::AutoName, value, $crate::_insta_rustfmt_stringify!($value));
     }};
 }
 
@@ -331,15 +338,15 @@ macro_rules! assert_debug_snapshot {
 macro_rules! assert_display_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         let value = format!("{}", $value);
-        $crate::assert_snapshot!(value, stringify!($value), @$snapshot);
+        $crate::assert_snapshot!(value, $crate::_insta_rustfmt_stringify!($value), @$snapshot);
     }};
     ($name:expr, $value:expr) => {{
         let value = format!("{}", $value);
-        $crate::assert_snapshot!(Some($name), value, stringify!($value));
+        $crate::assert_snapshot!(Some($name), value, $crate::_insta_rustfmt_stringify!($value));
     }};
     ($value:expr) => {{
         let value = format!("{}", $value);
-        $crate::assert_snapshot!($crate::_macro_support::AutoName, value, stringify!($value));
+        $crate::assert_snapshot!($crate::_macro_support::AutoName, value, $crate::_insta_rustfmt_stringify!($value));
     }};
 }
 
@@ -365,7 +372,7 @@ macro_rules! assert_snapshot {
         $crate::assert_snapshot!(
             $crate::_macro_support::ReferenceValue::Inline($snapshot),
             $value,
-            stringify!($value)
+            $crate::_insta_rustfmt_stringify!($value)
         )
     };
     ($value:expr, $debug_expr:expr, @$snapshot:literal) => {
@@ -376,7 +383,7 @@ macro_rules! assert_snapshot {
         )
     };
     ($name:expr, $value:expr) => {
-        $crate::assert_snapshot!($name, $value, stringify!($value))
+        $crate::assert_snapshot!($name, $value, $crate::_insta_rustfmt_stringify!($value))
     };
     ($name:expr, $value:expr, $debug_expr:expr) => {
         $crate::_macro_support::assert_snapshot(
@@ -392,7 +399,11 @@ macro_rules! assert_snapshot {
         .unwrap();
     };
     ($value:expr) => {
-        $crate::assert_snapshot!($crate::_macro_support::AutoName, $value, stringify!($value))
+        $crate::assert_snapshot!(
+            $crate::_macro_support::AutoName,
+            $value,
+            $crate::_insta_rustfmt_stringify!($value)
+        )
     };
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -72,7 +72,7 @@ fn term_width() -> usize {
     }
 }
 
-fn format_rust_expression(value: &str) -> Cow<'_, str> {
+pub fn format_rust_expression(value: &str) -> Cow<'_, str> {
     const PREFIX: &str = "const x:() = ";
     const SUFFIX: &str = ";\n";
     if let Ok(mut proc) = Command::new("rustfmt")
@@ -216,7 +216,7 @@ fn print_changeset(old: &str, new: &str, expr: Option<&str>) {
 
     if let Some(expr) = expr {
         println!("{:─^1$}", "", width,);
-        println!("{}", style(format_rust_expression(expr)));
+        println!("{}", style(expr));
     }
     println!("────────────┬{:─^1$}", "", width.saturating_sub(13));
     let mut has_changes = false;

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -73,13 +73,13 @@ impl PendingInlineSnapshot {
 pub struct MetaData {
     /// The source file (relative to workspace root).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) source: Option<String>,
+    pub source: Option<String>,
     /// Optionally the expression that created the snapshot.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) expression: Option<String>,
+    pub expression: Option<String>,
     /// Reference to the input file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) input_file: Option<String>,
+    pub input_file: Option<String>,
 }
 
 impl MetaData {
@@ -127,8 +127,8 @@ impl Snapshot {
         DefaultSnapfileFormatter::deserialize(&mut f, p.as_ref().file_name().unwrap())
     }
 
-    /// Creates an empty snapshot.
-    pub(crate) fn from_components(
+    /// Creates a snapshot from its parts.
+    pub fn from_components(
         module_name: String,
         snapshot_name: Option<String>,
         metadata: MetaData,
@@ -219,6 +219,10 @@ impl SnapshotContents {
         out.push_str(if is_escape { "\"###" } else { "\"" });
 
         out
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 


### PR DESCRIPTION
This also includes a refactor towards moving snapfile de/serialization into a trait, such that alternate snapfile formats are easier to make. (Such as one that printed the captured expression in multiline structure rather than single-line!)

The main benefits of rustfmt-early here is that it fixes #177. If the user provides an expression to the macro directly, then we should preserve it and not mangle it, as the exact content of it might matter, including whitespace, even if it happens to be parsable as a rust expression. So instead, we create and use a `stringify!` variant that calls our rustfmt wrapper for us immediately, so we stringify to formatted Rust code, which we save to the snapfile.

There are two key downsides to this simple approach, though:

- Old snapfiles won't be updated, and will display the pre-rustfmt'd snippet now. I'm not sure how much of a deal this is in practice: is the old or the new expression used for `cargo insta review`? Are they diffed?
- rustfmt happens at snapshot test time, rather than review time. That means that if someone who doesn't have rustfmt installed creates the new snapshot files, then they will show up as not rustfmt'd for everyone, rather than being rustfmt'd on the fly by people who do have rustfmt. I honestly think this is a reasonable enough tradeoff -- most people who would be blessing insta tests have rustfmt installed anyway -- but I'm definitely a bit biased, being a main benefactor from this change.

A more complex solution is possible, and was my original intent before simplifying: store an extra flag for "wants a rustfmt" in the snapshot. It would default to true (to be compatible with existing snapshots), but new snapshots (or even just custom snapfile formats) could write that it wants to not be rustfmt'd. This would be fully transparent and avoid changing any current behavior, but at the cost of complexity I don't think is strictly necessary.

Best reviewed commit-by-commit.