### PR TITLE
Allow passing options to cargo test

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -139,6 +139,10 @@ pub struct TestCommand {
     /// Delete unreferenced snapshots after the test run.
     #[structopt(long)]
     pub delete_unreferenced_snapshots: bool,
+    /// Options passed to cargo test
+    // Sets raw to true so that `--` is required
+    #[structopt(name = "cargo_options", raw(true))]
+    pub cargo_options: Vec<String>,
 }
 
 #[derive(StructOpt, Debug)]
@@ -543,6 +547,7 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
     }
     proc.arg("--color");
     proc.arg(color);
+    proc.args(cmd.cargo_options);
     proc.arg("--");
     proc.arg("-q");
 


### PR DESCRIPTION
This PR allows passing arguments to cargo test when `cargo insta test` is run, by doing passing arguments after a `--`
e.g. `cargo insta test -- --test test_name`

Closes #182 

Other options which were normally forwarded to cargo test such as `cargo insta test --release` or `cargo insta test --features feature_name` were left for backwards compatibility. They should probably be deprecated in favour of `cargo insta test -- --release` etc., not sure if you want to put a message as such or just leave it?