### PR TITLE
Added the ability to redact collection keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.8.0
+
+- Added the ability to redact into a key. (#192)
+
 ## 1.7.2
 
 - Fixed an issue where selectors could not start with underscore. (#189)

--- a/src/redaction.rs
+++ b/src/redaction.rs
@@ -417,10 +417,15 @@ impl<'a> Selector<'a> {
                 Content::Map(map) => Content::Map(
                     map.into_iter()
                         .map(|(key, value)| {
+                            path.push(PathItem::Field("$key"));
+                            let new_key = self.redact_impl(key.clone(), redaction, path);
+                            path.pop();
+
                             path.push(PathItem::Content(key.clone()));
                             let new_value = self.redact_impl(value, redaction, path);
                             path.pop();
-                            (key, new_value)
+
+                            (new_key, new_value)
                         })
                         .collect(),
                 ),

--- a/src/select_grammar.pest
+++ b/src/select_grammar.pest
@@ -1,6 +1,6 @@
 WHITESPACE = _{ WHITE_SPACE }
 
-ident = @{ ( "_" | XID_START ) ~ XID_CONTINUE* }
+ident = @{ ( "_" | "$" | XID_START ) ~ XID_CONTINUE* }
 deep_wildcard = { "." ~ "**" }
 wildcard = { "." ~ "*" }
 key = @{ "." ~ ident }

--- a/tests/snapshots/test_redaction__map_key_redaction.snap
+++ b/tests/snapshots/test_redaction__map_key_redaction.snap
@@ -1,0 +1,10 @@
+---
+source: tests/test_redaction.rs
+expression: foo
+---
+hm:
+  ? bucket: "[bucket]"
+    value: 0
+  : 42
+btm:
+  "[key]": 23

--- a/tests/test_redaction.rs
+++ b/tests/test_redaction.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "redactions")]
 
+use std::collections::{BTreeMap, HashMap};
+
 use insta::_macro_support::Selector;
 use insta::{
     assert_debug_snapshot, assert_json_snapshot, assert_yaml_snapshot, with_settings, Settings,
@@ -305,5 +307,37 @@ fn test_struct_array_redaction() {
         "[]._id" => "[checkout_id]",
         "[].products[]._id" => "[product_id]",
         "[].products[].product_name" => "[product_name]",
+    });
+}
+
+#[test]
+fn test_map_key_redaction() {
+    #[derive(Serialize, Hash, PartialEq, PartialOrd, Eq, Ord)]
+    struct Key {
+        bucket: u32,
+        value: u32,
+    }
+
+    #[derive(Serialize)]
+    struct Foo {
+        hm: HashMap<Key, u32>,
+        btm: BTreeMap<(u32, u32), u32>,
+    }
+
+    let mut hm = HashMap::new();
+    hm.insert(
+        Key {
+            bucket: 1,
+            value: 0,
+        },
+        42,
+    );
+    let mut btm = BTreeMap::new();
+    btm.insert((0, 0), 23);
+    let foo = Foo { hm, btm };
+
+    insta::assert_yaml_snapshot!(foo, {
+        ".hm.$key.bucket" => "[bucket]",
+        ".btm.$key" => "[key]",
     });
 }


### PR DESCRIPTION
This adds the ability to redact keys in collections by using the special `$key` field.

Fixes #192