### PR TITLE
This fixes cargo-insta not handling -p correctly when deleting snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.9.0
+
+- `cargo-insta` now correctly handles the package (`-p`) argument
+  on `test` when deleting unreferenced snapshots. (#201)
+
 ## 1.8.0
 
 - Added the ability to redact into a key. (#192)


### PR DESCRIPTION
The `-p` flag is not part of `TargetArgs` but the test argument. As a result it was handled correctly when stepping through the folder tree when snapshot deletion was requested. This now fixes this behavior. Additionally if the last snapshot test was removed an IO error was triggered which is no longer the case now.

This fixes #201 