### PR TITLE
Include assertion line numbers in snapshot files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.8.0
 
 - Added the ability to redact into a key. (#192)
+- Insta now memorizes assertion line numbers in snapshots.  While these
+  will quickly be old, they are often useful when reviewing snapshots
+  immediately after creation with `cargo-insta`. (#191)
 
 ## 1.7.2
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -10,8 +10,13 @@ pub fn print_snapshot_summary(
     workspace_root: &Path,
     snapshot: &Snapshot,
     snapshot_file: Option<&Path>,
-    line: Option<u32>,
+    mut line: Option<u32>,
 ) {
+    // default to old assertion line from snapshot.
+    if line.is_none() {
+        line = snapshot.metadata().assertion_line();
+    }
+
     if let Some(snapshot_file) = snapshot_file {
         let snapshot_file = workspace_root
             .join(snapshot_file)
@@ -53,8 +58,13 @@ pub fn print_snapshot_diff(
     new: &Snapshot,
     old_snapshot: Option<&Snapshot>,
     snapshot_file: Option<&Path>,
-    line: Option<u32>,
+    mut line: Option<u32>,
 ) {
+    // default to old assertion line from snapshot.
+    if line.is_none() {
+        line = new.metadata().assertion_line();
+    }
+
     print_snapshot_summary(workspace_root, new, snapshot_file, line);
     let old_contents = old_snapshot.as_ref().map_or("", |x| x.contents_str());
     let new_contents = new.contents_str();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -313,6 +313,7 @@ impl<'a> SnapshotAssertionContext<'a> {
             MetaData::new(
                 self.assertion_file,
                 expr,
+                Some(self.assertion_line),
                 Settings::with(|s| s.input_file().and_then(|x| self.localize_path(x))),
             ),
             contents,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -73,6 +73,9 @@ pub struct MetaData {
     /// The source file (relative to workspace root).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) source: Option<String>,
+    /// The source line if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) assertion_line: Option<u32>,
     /// Optionally the expression that created the snapshot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) expression: Option<String>,
@@ -83,10 +86,16 @@ pub struct MetaData {
 
 impl MetaData {
     /// Creates a new metadata from the given inputs.
-    pub(crate) fn new(source: &str, expr: &str, input_file: Option<PathBuf>) -> MetaData {
+    pub(crate) fn new(
+        source: &str,
+        expr: &str,
+        assertion_line: Option<u32>,
+        input_file: Option<PathBuf>,
+    ) -> MetaData {
         MetaData {
             source: Some(path_to_storage(source)),
             expression: Some(expr.to_string()),
+            assertion_line,
             input_file: input_file.map(path_to_storage),
         }
     }
@@ -94,6 +103,11 @@ impl MetaData {
     /// Returns the absolute source path.
     pub fn source(&self) -> Option<&str> {
         self.source.as_deref()
+    }
+
+    /// Returns the assertion line.
+    pub fn assertion_line(&self) -> Option<u32> {
+        self.assertion_line
     }
 
     /// Returns the expression that created the snapshot.


### PR DESCRIPTION
Previously line numbers for assertions were intentionally not included as they are getting stale quickly. However immediately after the creation of a snapshot they are still accurate and useful for display in insta.

This fixes #191