### PR TITLE
Detect snapshot names from function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.12.0
 
 - Add support for sorting redactions (`sorted_redaction` and `Settings::sort_selector`). (#212)
+- Changed snapshot name detection to no longer use thread names but function names. (#213)
 
 ## 1.11.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ colors = ["console"]
 # This feature is now just always enabled because we use yaml internally now.
 serialization = []
 
+# This feature is no longer used as snapshot name detection was changed.
+backtrace = []
+
 [dependencies]
 csv = { version = "1.1.4", optional = true }
 serde = { version = "1.0.117", features = ["derive"] }
@@ -42,7 +45,6 @@ serde_json = "1.0.59"
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.7.0", optional = true }
-backtrace = { version = "0.3.55", optional = true }
 toml = { version = "0.5.7", optional = true }
 globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,17 @@
+/// Utility macro to return the name of the current function.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _function_name {
+    () => {{
+        fn f() {}
+        fn type_name_of_val<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of_val(f).strip_suffix("::f").unwrap_or("");
+        name.strip_suffix("::{{closure}}").unwrap_or(name)
+    }};
+}
+
 /// Asserts a `Serialize` snapshot in CSV format.
 ///
 /// **Feature:** `csv` (disabled by default)
@@ -384,6 +398,7 @@ macro_rules! assert_snapshot {
             $name.into(),
             &$value,
             env!("CARGO_MANIFEST_DIR"),
+            $crate::_function_name!(),
             module_path!(),
             file!(),
             line!(),

--- a/tests/snapshots/test_inline__unnamed_thread_single_line-2.snap
+++ b/tests/snapshots/test_inline__unnamed_thread_single_line-2.snap
@@ -1,5 +1,7 @@
 ---
 source: tests/test_inline.rs
+assertion_line: 41
 expression: "\"Testing-thread-2\""
+
 ---
 Testing-thread-2

--- a/tests/snapshots/test_inline__unnamed_thread_single_line.snap
+++ b/tests/snapshots/test_inline__unnamed_thread_single_line.snap
@@ -1,5 +1,7 @@
 ---
 source: tests/test_inline.rs
+assertion_line: 40
 expression: "\"Testing-thread\""
+
 ---
 Testing-thread

--- a/tests/test_clash_detection.rs
+++ b/tests/test_clash_detection.rs
@@ -1,7 +1,13 @@
 use std::env;
 use std::thread;
 
-use similar_asserts::assert_eq;
+fn test_foo_always_missing() {
+    insta::assert_debug_snapshot!(42);
+}
+
+fn foo_always_missing() {
+    insta::assert_debug_snapshot!(42);
+}
 
 #[test]
 fn test_clash_detection() {
@@ -11,17 +17,15 @@ fn test_clash_detection() {
     env::set_var("INSTA_FORCE_PASS", "0");
 
     let err1 = thread::Builder::new()
-        .name("test_foo_always_missing".into())
         .spawn(|| {
-            insta::assert_debug_snapshot!(42);
+            test_foo_always_missing();
         })
         .unwrap()
         .join()
         .unwrap_err();
     let err2 = thread::Builder::new()
-        .name("foo_always_missing".into())
         .spawn(|| {
-            insta::assert_debug_snapshot!(42);
+            foo_always_missing();
         })
         .unwrap()
         .join()
@@ -44,6 +48,6 @@ fn test_clash_detection() {
     values.sort();
     assert_eq!(&values[..], &vec![
         "Insta snapshot name clash detected between \'foo_always_missing\' and \'test_foo_always_missing\' in \'test_clash_detection\'. Rename one function.",
-        "snapshot assertion for \'foo_always_missing\' failed in line 16",
+        "snapshot assertion for \'foo_always_missing\' failed in line 5",
     ][..]);
 }

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -31,6 +31,8 @@ fn test_unnamed_single_line() {
     assert_snapshot!("Testing-2");
 }
 
+// We used to use the thread name for snapshot name detection.  This is unreliable
+// so this test now basically does exactly the same as `test_unnamed_single_line`.
 #[test]
 fn test_unnamed_thread_single_line() {
     let builder = thread::Builder::new().name("foo::lol::something".into());


### PR DESCRIPTION
We used to detect the snapshot names form the current thread.  This has
been very unrealiable in a lot of cases.  This changes the behavior so
that the function name is used instead by using `std::any::type_name`.

This does change behavior slightly but most users should not notice this
change except if they relied on helper functions.  In that case using a
macro is a better solution most likely.

Refs #127 and #105