### PR TITLE
Remove assertion_line from stored snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.13.0
 
 - Fixed a bug where an extra newline was emitted following the snapshot header.
+- `assertion_line` is no longer retained in snapshots. (#218)
 
 ## 1.12.0
 

--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -221,7 +221,9 @@ impl SnapshotContainer {
             for snapshot in self.snapshots.iter() {
                 match snapshot.op {
                     Operation::Accept => {
-                        fs::rename(&self.snapshot_path, &self.target_path)?;
+                        let snapshot = Snapshot::from_file(&self.snapshot_path)?;
+                        snapshot.save(&self.target_path)?;
+                        fs::remove_file(&self.snapshot_path)?;
                     }
                     Operation::Reject => {
                         fs::remove_file(&self.snapshot_path)?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -328,7 +328,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                 if let Some(ref snapshot_file) = self.snapshot_file {
                     let mut new_path = snapshot_file.to_path_buf();
                     new_path.set_extension("snap.new");
-                    new_snapshot.save(&new_path)?;
+                    new_snapshot.save_new(&new_path)?;
                     if should_print {
                         elog!(
                             "{} {}",

--- a/src/snapshots/insta__test__embedded.snap
+++ b/src/snapshots/insta__test__embedded.snap
@@ -1,6 +1,5 @@
 ---
 source: src/test.rs
-assertion_line: 3
 expression: "\"Just a string\""
 ---
 Just a string

--- a/tests/snapshots/snapshot_no_module_prepending.snap
+++ b/tests/snapshots/snapshot_no_module_prepending.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_settings.rs
-assertion_line: 74
 expression: "vec![1, 2, 3]"
 ---
 - 1

--- a/tests/snapshots/test_basic__debug_vector.snap
+++ b/tests/snapshots/test_basic__debug_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 8
 expression: "vec![1, 2, 3]"
 ---
 [

--- a/tests/snapshots/test_basic__display.snap
+++ b/tests/snapshots/test_basic__display.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 69
 expression: td
 ---
 TestDisplay struct

--- a/tests/snapshots/test_basic__json_vector.snap
+++ b/tests/snapshots/test_basic__json_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 41
 expression: "vec![1, 2, 3]"
 ---
 [

--- a/tests/snapshots/test_basic__nested__nested_module.snap
+++ b/tests/snapshots/test_basic__nested__nested_module.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 54
 expression: "\"aoeu\""
 ---
 aoeu

--- a/tests/snapshots/test_basic__unnamed_debug_vector-2.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 14
 expression: "vec![1, 2, 3, 4]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_debug_vector-3.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector-3.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 15
 expression: "vec![1, 2, 3, 4, 5]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_debug_vector.snap
+++ b/tests/snapshots/test_basic__unnamed_debug_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 13
 expression: "vec![1, 2, 3]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_display-2.snap
+++ b/tests/snapshots/test_basic__unnamed_display-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 76
 expression: "\"whatever\""
 ---
 whatever

--- a/tests/snapshots/test_basic__unnamed_display.snap
+++ b/tests/snapshots/test_basic__unnamed_display.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 75
 expression: td
 ---
 TestDisplay struct

--- a/tests/snapshots/test_basic__unnamed_json_vector-2.snap
+++ b/tests/snapshots/test_basic__unnamed_json_vector-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 47
 expression: "vec![1, 2, 3, 4]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_json_vector-3.snap
+++ b/tests/snapshots/test_basic__unnamed_json_vector-3.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 48
 expression: "vec![1, 2, 3, 4, 5]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_json_vector.snap
+++ b/tests/snapshots/test_basic__unnamed_json_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 46
 expression: "vec![1, 2, 3]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_nested_closure.snap
+++ b/tests/snapshots/test_basic__unnamed_nested_closure.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 22
 expression: "vec![1, 2, 3]"
 ---
 [

--- a/tests/snapshots/test_basic__unnamed_yaml_vector-2.snap
+++ b/tests/snapshots/test_basic__unnamed_yaml_vector-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 35
 expression: "vec![1, 2, 3, 4]"
 ---
 - 1

--- a/tests/snapshots/test_basic__unnamed_yaml_vector-3.snap
+++ b/tests/snapshots/test_basic__unnamed_yaml_vector-3.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 36
 expression: "vec![1, 2, 3, 4, 5]"
 ---
 - 1

--- a/tests/snapshots/test_basic__unnamed_yaml_vector.snap
+++ b/tests/snapshots/test_basic__unnamed_yaml_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 34
 expression: "vec![1, 2, 3]"
 ---
 - 1

--- a/tests/snapshots/test_basic__yaml_vector.snap
+++ b/tests/snapshots/test_basic__yaml_vector.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_basic.rs
-assertion_line: 29
 expression: "vec![1, 2, 3]"
 ---
 - 1

--- a/tests/snapshots/test_bugs__crlf.snap
+++ b/tests/snapshots/test_bugs__crlf.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_bugs.rs
-assertion_line: 3
 expression: "\"foo\\r\\nbar\\r\\nbaz\""
 ---
 foo

--- a/tests/snapshots/test_bugs__trailing_crlf.snap
+++ b/tests/snapshots/test_bugs__trailing_crlf.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_bugs.rs
-assertion_line: 8
 expression: "\"foo\\r\\nbar\\r\\nbaz\\r\\n\""
 ---
 foo

--- a/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@goodbye.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_glob.rs
-assertion_line: 7
 expression: "&contents"
 input_file: tests/inputs/goodbye.txt
 ---

--- a/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
+++ b/tests/snapshots/test_glob__basic_globbing@hello.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_glob.rs
-assertion_line: 7
 expression: "&contents"
 input_file: tests/inputs/hello.txt
 ---

--- a/tests/snapshots/test_glob__globs_follow_links@goodbye.txt.snap
+++ b/tests/snapshots/test_glob__globs_follow_links@goodbye.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_glob.rs
-assertion_line: 15
 expression: "&contents"
 input_file: tests/inputs/goodbye.txt
 ---

--- a/tests/snapshots/test_glob__globs_follow_links@hello.txt.snap
+++ b/tests/snapshots/test_glob__globs_follow_links@hello.txt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_glob.rs
-assertion_line: 15
 expression: "&contents"
 input_file: tests/inputs/hello.txt
 ---

--- a/tests/snapshots/test_inline__unnamed_single_line-2.snap
+++ b/tests/snapshots/test_inline__unnamed_single_line-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_inline.rs
-assertion_line: 31
 expression: "\"Testing-2\""
 ---
 Testing-2

--- a/tests/snapshots/test_inline__unnamed_single_line.snap
+++ b/tests/snapshots/test_inline__unnamed_single_line.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_inline.rs
-assertion_line: 30
 expression: "\"Testing\""
 ---
 Testing

--- a/tests/snapshots/test_inline__unnamed_thread_single_line-2.snap
+++ b/tests/snapshots/test_inline__unnamed_thread_single_line-2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_inline.rs
-assertion_line: 43
 expression: "\"Testing-thread-2\""
 ---
 Testing-thread-2

--- a/tests/snapshots/test_inline__unnamed_thread_single_line.snap
+++ b/tests/snapshots/test_inline__unnamed_thread_single_line.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_inline.rs
-assertion_line: 42
 expression: "\"Testing-thread\""
 ---
 Testing-thread

--- a/tests/snapshots/test_redaction__foo_bar.snap
+++ b/tests/snapshots/test_redaction__foo_bar.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 22
 expression: "Selector::parse(\".foo.bar\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_alt.snap
+++ b/tests/snapshots/test_redaction__foo_bar_alt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 23
 expression: "Selector::parse(\".foo[\\\"bar\\\"]\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_deep.snap
+++ b/tests/snapshots/test_redaction__foo_bar_deep.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 28
 expression: "Selector::parse(\".foo.bar.**\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_full_range.snap
+++ b/tests/snapshots/test_redaction__foo_bar_full_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 24
 expression: "Selector::parse(\".foo.bar[]\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_range.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 27
 expression: "Selector::parse(\".foo.bar[10:20]\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_range_from.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range_from.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 26
 expression: "Selector::parse(\".foo.bar[10:]\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__foo_bar_range_to.snap
+++ b/tests/snapshots/test_redaction__foo_bar_range_to.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 25
 expression: "Selector::parse(\".foo.bar[:10]\").unwrap()"
 ---
 Selector {

--- a/tests/snapshots/test_redaction__map_key_redaction.snap
+++ b/tests/snapshots/test_redaction__map_key_redaction.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 340
 expression: foo
 ---
 hm:

--- a/tests/snapshots/test_redaction__struct_array_redaction.snap
+++ b/tests/snapshots/test_redaction__struct_array_redaction.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 307
 expression: "vec![checkout]"
 ---
 - _id: "[checkout_id]"

--- a/tests/snapshots/test_redaction__user.snap
+++ b/tests/snapshots/test_redaction__user.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 56
 expression: "&User{id: 23,\n      username: \"john_doe\".to_string(),\n      email: Email(\"john@example.com\".to_string()),\n      extra: \"\".to_string(),}"
 ---
 id: "[id]"

--- a/tests/snapshots/test_redaction__user_csv.snap
+++ b/tests/snapshots/test_redaction__user_csv.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 85
 expression: "&User{id: 44,\n      username: \"julius_csv\".to_string(),\n      email: Email(\"julius@example.com\".to_string()),\n      extra: \"\".to_string(),}"
 ---
 id,username,email,extra

--- a/tests/snapshots/test_redaction__user_json.snap
+++ b/tests/snapshots/test_redaction__user_json.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 123
 expression: "&User{id: 9999,\n      username: \"jason_doe\".to_string(),\n      email: Email(\"jason@example.com\".to_string()),\n      extra: \"ssn goes here\".to_string(),}"
 ---
 {

--- a/tests/snapshots/test_redaction__user_json_flags.snap
+++ b/tests/snapshots/test_redaction__user_json_flags.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 359
 expression: "&User{id: 122,\n      username: \"jason_doe\".to_string(),\n      flags:\n          vec![\"zzz\".into(), \"foo\".into(), \"aha\".into(),\n               \"is_admin\".into()].into_iter().collect(),}"
 ---
 {

--- a/tests/snapshots/test_redaction__user_json_flags_alt.snap
+++ b/tests/snapshots/test_redaction__user_json_flags_alt.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 384
 expression: "&User{id: 122,\n      username: \"jason_doe\".to_string(),\n      flags:\n          MySet(vec![\"zzz\".into(), \"foo\".into(), \"aha\".into(),\n                     \"is_admin\".into()].into_iter().collect()),}"
 ---
 {

--- a/tests/snapshots/test_redaction__user_json_settings.snap
+++ b/tests/snapshots/test_redaction__user_json_settings.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 140
 expression: "&User{id: 122,\n      username: \"jason_doe\".to_string(),\n      email: Email(\"jason@example.com\".to_string()),\n      extra: \"ssn goes here\".to_string(),}"
 ---
 {

--- a/tests/snapshots/test_redaction__user_json_settings_callback.snap
+++ b/tests/snapshots/test_redaction__user_json_settings_callback.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 161
 expression: "&User{id: 1234,\n      username: \"jason_doe\".to_string(),\n      email: Email(\"jason@example.com\".to_string()),\n      extra: \"extra here\".to_string(),}"
 ---
 {

--- a/tests/snapshots/test_redaction__user_ron.snap
+++ b/tests/snapshots/test_redaction__user_ron.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 98
 expression: "&User{id: 53,\n      username: \"john_ron\".to_string(),\n      email: Email(\"john@example.com\".to_string()),\n      extra: \"\".to_string(),}"
 ---
 User(

--- a/tests/snapshots/test_redaction__user_toml.snap
+++ b/tests/snapshots/test_redaction__user_toml.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 111
 expression: "&User{id: 53,\n      username: \"john_ron\".to_string(),\n      email: Email(\"john@example.com\".to_string()),\n      extra: \"\".to_string(),}"
 ---
 id = '[id]'

--- a/tests/snapshots/test_redaction__with_random_value_json_settings2.snap
+++ b/tests/snapshots/test_redaction__with_random_value_json_settings2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_redaction.rs
-assertion_line: 179
 expression: "&User{id: 975,\n      username: \"jason_doe\".to_string(),\n      email: Email(\"jason@example.com\".to_string()),\n      extra: \"ssn goes here\".to_string(),}"
 ---
 {

--- a/tests/snapshots/test_suffixes__basic_suffixes@1.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@1.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_suffixes.rs
-assertion_line: 5
 expression: "&value"
 ---
 1

--- a/tests/snapshots/test_suffixes__basic_suffixes@2.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@2.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_suffixes.rs
-assertion_line: 5
 expression: "&value"
 ---
 2

--- a/tests/snapshots/test_suffixes__basic_suffixes@3.snap
+++ b/tests/snapshots/test_suffixes__basic_suffixes@3.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_suffixes.rs
-assertion_line: 5
 expression: "&value"
 ---
 3

--- a/tests/snapshots2/test_settings__snapshot_path.snap
+++ b/tests/snapshots2/test_settings__snapshot_path.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/test_settings.rs
-assertion_line: 67
 expression: "vec![1, 2, 3]"
 ---
 - 1


### PR DESCRIPTION
This removes the `assertion_line` meta information from stored snapshots.

Fixes #215