### PR TITLE
Do not panic on outdated inline snapshots

### DIFF
--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -128,15 +128,18 @@ impl SnapshotContainer {
                     pending_vec.sort_by_key(|pending| pending.line);
                     for (id, pending) in pending_vec.into_iter().enumerate() {
                         if let Some(new) = pending.new {
-                            snapshots.push(PendingSnapshot {
-                                id,
-                                old: pending.old,
-                                new,
-                                op: Operation::Skip,
-                                line: Some(pending.line),
-                            });
-                            patcher.add_snapshot_macro(pending.line as usize);
-                            have_new = true;
+                            if patcher.add_snapshot_macro(pending.line as usize) {
+                                snapshots.push(PendingSnapshot {
+                                    id,
+                                    old: pending.old,
+                                    new,
+                                    op: Operation::Skip,
+                                    line: Some(pending.line),
+                                });
+                                have_new = true;
+                            } else {
+                                // this is an outdated snapshot and the file changed.
+                            }
                         }
                     }
                     Some(patcher)

--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -54,16 +54,17 @@ impl FilePatcher {
         Ok(())
     }
 
-    pub fn add_snapshot_macro(&mut self, line: usize) {
+    pub fn add_snapshot_macro(&mut self, line: usize) -> bool {
         match self.find_snapshot_macro(line) {
             Some(snapshot) => {
                 assert!(self
                     .inline_snapshots
                     .last()
                     .map_or(true, |x| x.end.0 <= line));
-                self.inline_snapshots.push(snapshot)
+                self.inline_snapshots.push(snapshot);
+                true
             }
-            None => panic!("Could not find snapshot in line {}", line),
+            None => false,
         }
     }
 


### PR DESCRIPTION
The code assumed that inline snapshots do not linger around for too long. This caused panics if the files were changed between when the inline snapshot was created and it was applied. Now this case is silently ignored.

Fixes #220 