### PR TITLE
Set non zero status code for pending tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Fixed a bug that caused insta to panic if inline snapshot assertions
   moved since the time of the snapshot creation. (#220)
+- `cargo insta test` now returns non zero status code when snapshots
+  are left for review. (#222)
 
 ## 1.13.0
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -667,6 +667,7 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
                 if snapshot_count != 1 { "s" } else { "" }
             );
             eprintln!("use `cargo insta review` to review snapshots");
+            return Err(QuietExit(1).into());
         } else {
             println!("{}: no snapshots to review", style("info").bold());
         }


### PR DESCRIPTION
This changes cargo-insta to return a non zero status code when snapshots are left for review.

Fixes #222