### PR TITLE
Use inline block format also for strings of form "foo\n"

### DIFF
--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -317,12 +317,12 @@ impl SnapshotContents {
     pub fn to_inline(&self, indentation: usize) -> String {
         let contents = &self.0;
         let mut out = String::new();
-        let is_escape = contents.lines().count() > 1 || contents.contains(&['\\', '"'][..]);
+        let is_escape = contents.contains(&['\n', '\\', '"'][..]);
 
         out.push_str(if is_escape { "r###\"" } else { "\"" });
         // if we have more than one line we want to change into the block
         // representation mode
-        if contents.lines().count() > 1 {
+        if contents.contains('\n') {
             out.extend(
                 contents
                     .lines()
@@ -509,6 +509,16 @@ b"[1..];
     a
 
     b
+\"###"
+    );
+
+    let t = &"
+    ab
+"[1..];
+    assert_eq!(
+        SnapshotContents(t.to_string()).to_inline(0),
+        "r###\"
+    ab
 \"###"
     );
 


### PR DESCRIPTION
The generated inline strings for snapshots with a single trailing
newline currently look something like this:

```
    insta::assert_snapshot!(stdout, @"foo
");
```

The unindented line there is distracting. I think it looks neater with
the block-style strings, like this:

```
    insta::assert_snapshot!(stdout, @###"
    foo
    "###);
```

I suspect the reason it isn't currently generated like that is just an
oversight caused by the fact that Rust's `str::lines()` returns a
single line for that kind of strings. This patch fixes it by looking
for `\n` characters instead.