### PR TITLE
test: make test for #88 effective

### DIFF
--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -785,16 +785,16 @@ b"[1..];
     );
 
     let t = &"
-    a
+a
 
-    b"[1..];
+b"[1..];
     assert_eq!(
-        SnapshotContents(t.to_string()).to_inline(0),
+        SnapshotContents(t.to_string()).to_inline(4),
         "r#\"
     a
 
     b
-\"#"
+    \"#"
     );
 
     let t = &"


### PR DESCRIPTION
The test added in 816df8856c28 doesn't seem to test what it was
supposed to test - it still passses after replacing `l.is_empty() { 0
} else { indentation }` by just `indentation`. With the change in this
patch, the test fails with that modification.