### PR TITLE
Add support for --no-quiet to cargo-insta test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 0.16.0
+
+- Added `--no-quiet`/`-Q` flag to `cargo insta test` to suppress the
+  quiet flag. This works around limitations with custom test harnesses
+  such as cucumber.
+
 ## 1.15.0
 
 - Bump minimum version of Rust to 1.56.1.  This was done because the used

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -140,6 +140,9 @@ pub struct TestCommand {
     /// Delete unreferenced snapshots after the test run.
     #[structopt(long)]
     pub delete_unreferenced_snapshots: bool,
+    /// Do not pass the quiet flag (`-q`) to tests.
+    #[structopt(short = "Q", long)]
+    pub no_quiet: bool,
     /// Options passed to cargo test
     // Sets raw to true so that `--` is required
     #[structopt(name = "cargo_options", raw(true))]
@@ -557,8 +560,11 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
     proc.arg("--color");
     proc.arg(color);
     proc.args(cmd.cargo_options);
-    proc.arg("--");
-    proc.arg("-q");
+
+    if !cmd.no_quiet {
+        proc.arg("--");
+        proc.arg("-q");
+    }
 
     if !cmd.keep_pending {
         process_snapshots(


### PR DESCRIPTION
This is a workaround for #235