### PR TITLE
Added info and description fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to insta and cargo-insta are documented here.
 - Improved ergonomics around `with_settings!`.  It's now a perfect match to
   the settings object's setter methods.
 - Added `description` and `info` to snapshots. (#239)
+- Added `omit_expression` setting. (#239)
 
 ## 1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to insta and cargo-insta are documented here.
 - Added `--no-quiet`/`-Q` flag to `cargo insta test` to suppress the
   quiet flag. This works around limitations with custom test harnesses
   such as cucumber.
+- Improved ergonomics around `with_settings!`.  It's now a perfect match to
+  the settings object's setter methods.
+- Added `description` to snapshots.
 
 ## 1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to insta and cargo-insta are documented here.
 - Update RON to 0.7.1.
 - Improved ergonomics around `with_settings!`.  It's now a perfect match to
   the settings object's setter methods.
-- Added `description` to snapshots.
+- Added `description` and `info` to snapshots. (#239)
 
 ## 1.15.0
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -432,6 +432,7 @@ macro_rules! assert_snapshot {
 /// Is equivalent to the following:
 ///
 /// ```rust
+/// # use insta::Settings;
 /// let mut settings = Settings::new();
 /// settings.set_sort_maps(true);
 /// settings.bind(|| {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -418,8 +418,8 @@ macro_rules! assert_snapshot {
 ///
 /// This macro lets you bind some settings temporarily.  The first argument
 /// takes key value pairs that should be set, the second is the block to
-/// execute.  All settings can be set (`sort_maps => value` maps roughly
-/// to `set_sort_maps(value)`).
+/// execute.  All settings can be set (`sort_maps => value` maps to `set_sort_maps(value)`).
+/// The exception are redactions which cannot be set this way.
 ///
 /// ```rust
 /// insta::with_settings!({sort_maps => true}, {
@@ -431,7 +431,7 @@ macro_rules! with_settings {
     ({$($k:ident => $v:expr),*$(,)?}, $body:block) => {{
         let mut settings = $crate::Settings::new();
         $(
-            settings._private_inner_mut().$k = $v.into();
+            settings._private_inner_mut().$k($v);
         )*
         settings.bind(|| $body)
     }}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -419,7 +419,7 @@ macro_rules! assert_snapshot {
 /// This macro lets you bind some settings temporarily.  The first argument
 /// takes key value pairs that should be set, the second is the block to
 /// execute.  All settings can be set (`sort_maps => value` maps to `set_sort_maps(value)`).
-/// The exception are redactions which cannot be set this way.
+/// The exception are redactions which can only be set to a vector this way.
 ///
 /// ```rust
 /// insta::with_settings!({sort_maps => true}, {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -416,13 +416,25 @@ macro_rules! assert_snapshot {
 
 /// Settings configuration macro.
 ///
-/// This macro lets you bind some settings temporarily.  The first argument
+/// This macro lets you bind some [`Settings`](crate::Settings) temporarily.  The first argument
 /// takes key value pairs that should be set, the second is the block to
 /// execute.  All settings can be set (`sort_maps => value` maps to `set_sort_maps(value)`).
 /// The exception are redactions which can only be set to a vector this way.
 ///
+/// This example:
+///
 /// ```rust
 /// insta::with_settings!({sort_maps => true}, {
+///     // run snapshot test here
+/// });
+/// ```
+///
+/// Is equivalent to the following:
+///
+/// ```rust
+/// let mut settings = Settings::new();
+/// settings.set_sort_maps(true);
+/// settings.bind(|| {
 ///     // run snapshot test here
 /// });
 /// ```

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -262,7 +262,11 @@ impl<'a> SnapshotAssertionContext<'a> {
                 source: Some(path_to_storage(self.assertion_file)),
                 assertion_line: Some(self.assertion_line),
                 description: settings.description().map(Into::into),
-                expression: Some(expr.to_string()),
+                expression: if settings.omit_expression() {
+                    None
+                } else {
+                    Some(expr.to_string())
+                },
                 info: settings.info(),
                 input_file: settings
                     .input_file()

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -263,6 +263,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                 assertion_line: Some(self.assertion_line),
                 description: settings.description().map(Into::into),
                 expression: Some(expr.to_string()),
+                info: settings.info(),
                 input_file: settings
                     .input_file()
                     .and_then(|x| self.localize_path(x))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -22,6 +22,7 @@ static DEFAULT_SETTINGS: Lazy<Arc<ActualSettings>> = Lazy::new(|| {
         input_file: None,
         description: None,
         info: None,
+        omit_expression: false,
         prepend_module_to_snapshot: true,
         #[cfg(feature = "redactions")]
         redactions: Redactions::default(),
@@ -57,6 +58,7 @@ pub struct ActualSettings {
     pub input_file: Option<PathBuf>,
     pub description: Option<String>,
     pub info: Option<serde_yaml::Value>,
+    pub omit_expression: bool,
     pub prepend_module_to_snapshot: bool,
     #[cfg(feature = "redactions")]
     pub redactions: Redactions,
@@ -87,6 +89,10 @@ impl ActualSettings {
 
     pub fn info<S: Serialize>(&mut self, value: &S) {
         self.info = Some(serde_yaml::to_value(value).unwrap());
+    }
+
+    pub fn omit_expression(&mut self, value: bool) {
+        self.omit_expression = value;
     }
 
     pub fn prepend_module_to_snapshot(&mut self, value: bool) {
@@ -308,6 +314,16 @@ impl Settings {
     /// Returns the current info
     pub fn has_info(&self) -> bool {
         self.inner.info.is_some()
+    }
+
+    /// If set to true, does not retain the expression in the snapshot.
+    pub fn set_omit_expression(&mut self, value: bool) {
+        self._private_inner_mut().omit_expression(value);
+    }
+
+    /// Returns true if expressions are omitted from snapshots.
+    pub fn omit_expression(&self) -> bool {
+        self.inner.omit_expression
     }
 
     /// Registers redactions that should be applied.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -86,6 +86,11 @@ impl ActualSettings {
         self.prepend_module_to_snapshot = value;
     }
 
+    #[cfg(feature = "redactions")]
+    pub fn redactions<R: Into<Redactions>>(&mut self, r: R) {
+        self.redactions = r.into();
+    }
+
     #[cfg(feature = "glob")]
     pub fn allow_empty_glob(&mut self, value: bool) {
         self.allow_empty_glob = value;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -262,7 +262,12 @@ impl Settings {
     /// Sets the description.
     ///
     /// The description is stored alongside the snapshot and will be displayed
-    /// in the diff UI.
+    /// in the diff UI.  When a snapshot is captured the Rust expression for that
+    /// snapshot is always retained.  However sometimes that information is not
+    /// super useful by itself, particularly when working with loops and generated
+    /// tests.  In that case the `description` can be set as extra information.
+    ///
+    /// See also [`set_info`](Self::set_info).
     pub fn set_description<S: Into<String>>(&mut self, value: S) {
         self._private_inner_mut().description(value);
     }
@@ -278,6 +283,14 @@ impl Settings {
     }
 
     /// Sets the info.
+    ///
+    /// The `info` is similar to `description` but for structured data.  This is
+    /// stored with the snapshot and shown in the review UI.  This for instance
+    /// can be used to show extended information that can make a reviewer better
+    /// understand what the snapshot is supposed to be testing.
+    ///
+    /// As an example the input paramters to the function that creates the snapshot
+    /// can be persisted here.
     pub fn set_info<S: Serialize>(&mut self, value: &S) {
         self._private_inner_mut().info(value);
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -19,6 +19,7 @@ static DEFAULT_SETTINGS: Lazy<Arc<ActualSettings>> = Lazy::new(|| {
         snapshot_path: "snapshots".into(),
         snapshot_suffix: "".into(),
         input_file: None,
+        description: None,
         prepend_module_to_snapshot: true,
         #[cfg(feature = "redactions")]
         redactions: Redactions::default(),
@@ -52,11 +53,43 @@ pub struct ActualSettings {
     pub snapshot_path: PathBuf,
     pub snapshot_suffix: String,
     pub input_file: Option<PathBuf>,
+    pub description: Option<String>,
     pub prepend_module_to_snapshot: bool,
     #[cfg(feature = "redactions")]
     pub redactions: Redactions,
     #[cfg(feature = "glob")]
     pub allow_empty_glob: bool,
+}
+
+impl ActualSettings {
+    pub fn sort_maps(&mut self, value: bool) {
+        self.sort_maps = value;
+    }
+
+    pub fn snapshot_path<P: AsRef<Path>>(&mut self, path: P) {
+        self.snapshot_path = path.as_ref().to_path_buf();
+    }
+
+    pub fn snapshot_suffix<I: Into<String>>(&mut self, suffix: I) {
+        self.snapshot_suffix = suffix.into();
+    }
+
+    pub fn input_file<P: AsRef<Path>>(&mut self, p: P) {
+        self.input_file = Some(p.as_ref().to_path_buf());
+    }
+
+    pub fn description<S: Into<String>>(&mut self, value: S) {
+        self.description = Some(value.into());
+    }
+
+    pub fn prepend_module_to_snapshot(&mut self, value: bool) {
+        self.prepend_module_to_snapshot = value;
+    }
+
+    #[cfg(feature = "glob")]
+    pub fn allow_empty_glob(&mut self, value: bool) {
+        self.allow_empty_glob = value;
+    }
 }
 
 /// Configures how insta operates at test time.
@@ -143,7 +176,7 @@ impl Settings {
     ///
     /// The default value is `true`.
     pub fn set_prepend_module_to_snapshot(&mut self, value: bool) {
-        self._private_inner_mut().prepend_module_to_snapshot = value;
+        self._private_inner_mut().prepend_module_to_snapshot(value);
     }
 
     /// Returns the current value for module name prepending.
@@ -160,7 +193,7 @@ impl Settings {
     /// The default value is `false`.
     #[cfg(feature = "glob")]
     pub fn set_allow_empty_glob(&mut self, value: bool) {
-        self._private_inner_mut().allow_empty_glob = value;
+        self._private_inner_mut().allow_empty_glob(value);
     }
 
     /// Returns the current value for the empty glob setting.
@@ -177,7 +210,7 @@ impl Settings {
     /// This is useful to separate snapshots if you want to use test
     /// parameterization.
     pub fn set_snapshot_suffix<I: Into<String>>(&mut self, suffix: I) {
-        self._private_inner_mut().snapshot_suffix = suffix.into();
+        self._private_inner_mut().snapshot_suffix(suffix);
     }
 
     /// Removes the snapshot suffix.
@@ -201,7 +234,7 @@ impl Settings {
     /// to the input file.  The path stored here is made relative to the
     /// workspace root before storing with the snapshot.
     pub fn set_input_file<P: AsRef<Path>>(&mut self, p: P) {
-        self._private_inner_mut().input_file = Some(p.as_ref().to_path_buf());
+        self._private_inner_mut().input_file(p);
     }
 
     /// Removes the input file reference.
@@ -212,6 +245,24 @@ impl Settings {
     /// Returns the current input file reference.
     pub fn input_file(&self) -> Option<&Path> {
         self.inner.input_file.as_deref()
+    }
+
+    /// Sets the description.
+    ///
+    /// The description is stored alongside the snapshot and will be displayed
+    /// in the diff UI.
+    pub fn set_description<S: Into<String>>(&mut self, value: S) {
+        self._private_inner_mut().description(value);
+    }
+
+    /// Removes the description.
+    pub fn remove_description(&mut self) {
+        self._private_inner_mut().description = None;
+    }
+
+    /// Returns the current description
+    pub fn description(&self) -> Option<&str> {
+        self.inner.description.as_deref()
     }
 
     /// Registers redactions that should be applied.
@@ -283,7 +334,7 @@ impl Settings {
     ///
     /// Defaults to `snapshots`.
     pub fn set_snapshot_path<P: AsRef<Path>>(&mut self, path: P) {
-        self._private_inner_mut().snapshot_path = path.as_ref().to_path_buf();
+        self._private_inner_mut().snapshot_path(path);
     }
 
     /// Returns the snapshot path.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -78,6 +78,9 @@ pub struct MetaData {
     /// Optionally the expression that created the snapshot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) expression: Option<String>,
+    /// An optional arbitrary structured info object.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) info: Option<serde_yaml::Value>,
     /// Reference to the input file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) input_file: Option<String>,
@@ -102,6 +105,12 @@ impl MetaData {
     /// Returns the description that created the snapshot.
     pub fn description(&self) -> Option<&str> {
         self.description.as_deref().filter(|x| !x.is_empty())
+    }
+
+    /// Returns the embedded info.
+    #[doc(hidden)]
+    pub fn private_info(&self) -> Option<&serde_yaml::Value> {
+        self.info.as_ref()
     }
 
     /// Returns the relative source path.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -7,8 +7,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
-use crate::utils::path_to_storage;
-
 static RUN_ID: Lazy<String> = Lazy::new(|| {
     let d = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     format!("{}-{}", d.as_secs(), d.subsec_nanos())
@@ -74,6 +72,9 @@ pub struct MetaData {
     /// The source line if available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) assertion_line: Option<u32>,
+    /// Optional human readable (non formatted) snapshot description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
     /// Optionally the expression that created the snapshot.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) expression: Option<String>,
@@ -83,21 +84,6 @@ pub struct MetaData {
 }
 
 impl MetaData {
-    /// Creates a new metadata from the given inputs.
-    pub(crate) fn new(
-        source: &str,
-        expr: &str,
-        assertion_line: Option<u32>,
-        input_file: Option<PathBuf>,
-    ) -> MetaData {
-        MetaData {
-            source: Some(path_to_storage(source)),
-            expression: Some(expr.to_string()),
-            assertion_line,
-            input_file: input_file.map(path_to_storage),
-        }
-    }
-
     /// Returns the absolute source path.
     pub fn source(&self) -> Option<&str> {
         self.source.as_deref()
@@ -111,6 +97,11 @@ impl MetaData {
     /// Returns the expression that created the snapshot.
     pub fn expression(&self) -> Option<&str> {
         self.expression.as_deref()
+    }
+
+    /// Returns the description that created the snapshot.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref().filter(|x| !x.is_empty())
     }
 
     /// Returns the relative source path.

--- a/tests/snapshots/test_settings__snapshot_with_description.snap
+++ b/tests/snapshots/test_settings__snapshot_with_description.snap
@@ -1,0 +1,9 @@
+---
+source: tests/test_settings.rs
+description: The snapshot are three integers
+expression: "vec![1, 2, 3]"
+---
+- 1
+- 2
+- 3
+

--- a/tests/snapshots/test_settings__snapshot_with_description_and_info.snap
+++ b/tests/snapshots/test_settings__snapshot_with_description_and_info.snap
@@ -1,0 +1,16 @@
+---
+source: tests/test_settings.rs
+description: The snapshot are four integers
+expression: "vec![1, 2, 3, 4]"
+info:
+  env:
+    ENVIRONMENT: production
+  cmdline:
+    - my-tool
+    - run
+---
+- 1
+- 2
+- 3
+- 4
+

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -74,3 +74,10 @@ fn test_snapshot_no_module_prepending() {
         assert_yaml_snapshot!(vec![1, 2, 3]);
     });
 }
+
+#[test]
+fn test_snapshot_with_description() {
+    with_settings!({description => "The snapshot are three integers"}, {
+        assert_yaml_snapshot!(vec![1, 2, 3])
+    });
+}

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -81,3 +81,19 @@ fn test_snapshot_with_description() {
         assert_yaml_snapshot!(vec![1, 2, 3])
     });
 }
+
+#[test]
+fn test_snapshot_with_description_and_info() {
+    #[derive(serde::Serialize)]
+    pub struct Info {
+        env: std::collections::HashMap<&'static str, &'static str>,
+        cmdline: Vec<&'static str>,
+    }
+    let info = Info {
+        env: From::from([("ENVIRONMENT", "production")]),
+        cmdline: vec!["my-tool", "run"],
+    };
+    with_settings!({description => "The snapshot are four integers", info => &info}, {
+        assert_yaml_snapshot!(vec![1, 2, 3, 4])
+    });
+}


### PR DESCRIPTION
This also refactors the internals for modifying settings via macros so
it's a perfect match to the public interface and adds a new `omit_expression`
flag to the settings to prevent the default expression to be written.

Fixes #238

Fixes #177