### PR TITLE
Added new filters feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Fixed an issue in `cargo-insta` where sometimes accepting inline snapshots
   would crash with an out of bounds panic.
+- Added new `filters` feature.
 
 ## 1.16.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ default = ["colors"]
 # snapshots.
 redactions = ["pest", "pest_derive"]
 
+# Enables support for running filters on snapshot
+filters = ["regex"]
+
 # Glob support
 glob = ["walkdir", "globset"]
 
@@ -50,6 +53,7 @@ globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }
 once_cell = "1.9.0"
+regex = { version = "1.6.0", default-features = false, optional = true, features = ["std", "unicode"] }
 
 [dev-dependencies]
 similar-asserts = "1.2.0"

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,0 +1,58 @@
+use std::borrow::Cow;
+
+use regex::Regex;
+
+#[derive(Debug, Default, Clone)]
+pub struct Filters {
+    rules: Vec<(Regex, String)>,
+}
+
+impl<'a> From<Vec<(&'a str, &'a str)>> for Filters {
+    fn from(value: Vec<(&'a str, &'a str)>) -> Filters {
+        let mut rv = Filters::default();
+        for (regex, replacement) in value {
+            rv.add(regex, replacement);
+        }
+        rv
+    }
+}
+
+impl Filters {
+    /// Adds a simple regex with a replacement.
+    pub(crate) fn add<S: Into<String>>(&mut self, regex: &str, replacement: S) {
+        self.rules.push((
+            Regex::new(regex).expect("invalid regex for snapshot filter rule"),
+            replacement.into(),
+        ));
+    }
+
+    /// Clears all filters.
+    pub(crate) fn clear(&mut self) {
+        self.rules.clear();
+    }
+
+    /// Applies all filters to the given snapshot.
+    pub(crate) fn apply_to<'s>(&self, s: &'s str) -> Cow<'s, str> {
+        let mut rv = Cow::Borrowed(s);
+
+        for (regex, replacement) in &self.rules {
+            match regex.replace_all(&rv, replacement) {
+                Cow::Borrowed(_) => continue,
+                Cow::Owned(value) => rv = Cow::Owned(value),
+            };
+        }
+
+        rv
+    }
+}
+
+#[test]
+fn test_filters() {
+    let mut filters = Filters::default();
+    filters.add("\\bhello\\b", "[NAME]");
+    filters.add("(a)", "[$1]");
+    assert_eq!(
+        filters.apply_to("hellohello hello abc"),
+        "hellohello [NAME] [a]bc"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@
 //! * `ron`: enables RON support ([`assert_ron_snapshot!`])
 //! * `toml`: enables TOML support ([`assert_toml_snapshot!`])
 //! * `redactions`: enables support for redactions
+//! * `filters`: enables support for filters
 //! * `glob`: enables support for globbing ([`glob!`])
 //! * `colors`: enables color output (enabled by default)
 //!
@@ -161,6 +162,9 @@ mod utils;
 #[cfg(feature = "redactions")]
 mod redaction;
 
+#[cfg(feature = "filters")]
+mod filters;
+
 #[cfg(feature = "glob")]
 mod glob;
 
@@ -176,6 +180,8 @@ pub use crate::snapshot::{MetaData, Snapshot};
 /// are exposed for documentation primarily.
 pub mod internals {
     pub use crate::content::Content;
+    #[cfg(feature = "filters")]
+    pub use crate::filters::Filters;
     pub use crate::runtime::AutoName;
     pub use crate::snapshot::{MetaData, SnapshotContents};
     #[cfg(feature = "redactions")]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -472,6 +472,11 @@ pub fn assert_snapshot(
         assertion_line,
     )?;
 
+    // apply filters if they are available
+    #[cfg(feature = "filters")]
+    let new_snapshot_value =
+        Settings::with(|settings| settings.filters().apply_to(new_snapshot_value));
+
     let new_snapshot = ctx.new_snapshot(new_snapshot_value.into(), expr);
 
     // memoize the snapshot file if requested.

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::error::Error;
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
@@ -346,6 +347,15 @@ impl SnapshotContents {
         out.push_str(if is_escape { "\"###" } else { "\"" });
 
         out
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for SnapshotContents {
+    fn from(value: Cow<'a, str>) -> Self {
+        match value {
+            Cow::Borrowed(s) => SnapshotContents::from(s),
+            Cow::Owned(s) => SnapshotContents::from(s),
+        }
     }
 }
 

--- a/tests/test_filters.rs
+++ b/tests/test_filters.rs
@@ -1,0 +1,12 @@
+#![cfg(feature = "filters")]
+
+use insta::{assert_snapshot, with_settings};
+
+#[test]
+fn test_basic_filter() {
+    with_settings!({filters => vec![
+        (r"\b[[:xdigit:]]{8}\b", "[SHORT_HEX]")
+    ]}, {
+        assert_snapshot!("Hello DEADBEEF!", @"Hello [SHORT_HEX]!");
+    })
+}


### PR DESCRIPTION
This adds a new filters feature which lets one run a regex over the snapshot before storing. This is useful for snapshots that originate in string form where redactions cannot be applied.