### PR TITLE
chore(deps): pin rust crates for cargo-insta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ once_cell = "1.9.0"
 regex = { version = "1.6.0", default-features = false, optional = true, features = ["std", "unicode"] }
 
 [dev-dependencies]
-similar-asserts = "1.2.0"
+similar-asserts = "=1.2.0"

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2018"
 readme = "README.md"
 
 [dependencies]
-insta = { version = "1.16.0", path = "..", features = ["redactions"] }
-console = "0.15.0"
-structopt = "0.3.20"
-serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0.59"
-proc-macro2 = { version = "1.0.24", features = ["span-locations"] }
-syn = { version = "1.0.50", features = ["full", "visit", "extra-traits"] }
-ignore = "0.4.17"
-uuid = { version = "1.0.0", features = ["v4"] }
+insta = { version = "=1.16.0", path = "..", features = ["redactions"] }
+console = "=0.15.0"
+structopt = "=0.3.20"
+serde = { version = "=1.0.117", features = ["derive"] }
+serde_json = "=1.0.59"
+proc-macro2 = { version = "=1.0.24", features = ["span-locations"] }
+syn = { version = "=1.0.50", features = ["full", "visit", "extra-traits"] }
+ignore = "=0.4.17"
+uuid = { version = "=1.0.0", features = ["v4"] }

--- a/cargo-insta/README.md
+++ b/cargo-insta/README.md
@@ -7,7 +7,7 @@
 snapshot reviews.
 
 ```
-$ cargo install cargo-insta
+$ cargo install --locked cargo-insta
 $ cargo insta --help
 ```
 

--- a/cargo-insta/src/main.rs
+++ b/cargo-insta/src/main.rs
@@ -6,7 +6,7 @@
 //! This crate provides a cargo command for insta snapshot reviews.
 //!
 //! ```text
-//! $ cargo install cargo-insta
+//! $ cargo install --locked cargo-insta
 //! $ cargo insta --help
 //! ```
 //!

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -8,5 +8,5 @@ NEW_VERSION="${1}"
 
 echo "Bumping version: ${NEW_VERSION}"
 perl -pi -e "s/^version = \".*?\"/version = \"$NEW_VERSION\"/" Cargo.toml
-perl -pi -e "s/^(insta.*)?version = \".*?\"/\$1version = \"$NEW_VERSION\"/" cargo-insta/Cargo.toml
+perl -pi -e "s/^(insta.*)?version = \".*?\"/\$1version = \"=$NEW_VERSION\"/" cargo-insta/Cargo.toml
 cd cargo-insta; cargo check


### PR DESCRIPTION
I ran into an issue when trying to install 1.15.0 after 1.16.0 was released

```console
$ cargo install cargo-insta --version 1.15.0
   ...
   Compiling insta v1.16.0
   Compiling cargo-insta v1.15.0
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
   --> /home/maxime/Documents/github.com/maxbrunet/automatic-timezoned/.local/share/cargo/registry/src/github.com-1ecc6299db9ec823/cargo-insta-1.15.0/src/cli.rs:185:5
    |
185 |     print_snapshot_diff(workspace_root, new, old, snapshot_file, line);
    |     ^^^^^^^^^^^^^^^^^^^ --------------  ---  ---  -------------  ---- supplied 5 arguments
    |     |
    |     expected 6 arguments
    |
note: function defined here
   --> /home/maxime/Documents/github.com/maxbrunet/automatic-timezoned/.local/share/cargo/registry/src/github.com-1ecc6299db9ec823/insta-1.16.0/src/output.rs:56:8
    |
56  | pub fn print_snapshot_diff(
    |        ^^^^^^^^^^^^^^^^^^^
```

The main problem is probably `cargo install` does not use the lock file by default (rust-lang/cargo#7169), so I have documented that `cargo-insta` should be installed with `--locked`.

The default requirement strategy is equivalent to a caret: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements 

Overall, I think it is good to pin dependencies in `Cargo.toml` for binaries, it will reduce the chances others run into troubles if `--locked` is not used. And I have also pinned the single dev dependency of `insta` (it make sense for the regular dependencies to be ranges like the absence of lock file).

Thank you for this awesome library! :heart: 