### PR TITLE
Fix build with minimal versions resolution

### DIFF
--- a/.github/workflows/minver.yml
+++ b/.github/workflows/minver.yml
@@ -1,0 +1,21 @@
+name: Check minimal version resolution
+
+on: [push]
+
+jobs:
+  check-minver:
+    name: Test with minimal version resolution
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - name: Test
+        run: make check-minver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ backtrace = []
 [dependencies]
 csv = { version = "1.1.4", optional = true }
 serde = { version = "1.0.117", features = ["derive"] }
-serde_yaml = "0.8.14"
+serde_yaml = "0.8.26"
 console = { version = "0.15.0", optional = true, default-features = false }
 serde_json = "1.0.59"
 pest = { version = "2.1.3", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ cargotest:
 	@cargo test --features redactions,backtrace -- --test-threads 1
 	@cd cargo-insta; cargo test
 
+check-minver:
+	@echo "MINVER CHECK"
+	@cargo minimal-versions check
+	@cargo minimal-versions check --all-features
+	@cargo minimal-versions check --no-default-features
+	@cargo minimal-versions check --features redactions,backtrace
+
 format:
 	@rustup component add rustfmt 2> /dev/null
 	@cargo fmt --all


### PR DESCRIPTION
This is not *critical*, as doing minimal version resolution requires nightly or non-automatic version selection. However, it's still good practice to try to keep minimal-versions correct and specify the versions that you need.