### PR TITLE
Add support for Settings::bind_to_scope

### DIFF
--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -55,16 +55,20 @@ fn test_bound_to_scope() {
     map.insert("c", "third value");
     map.insert("d", "fourth value");
 
-    let mut settings = Settings::new();
-    settings.set_sort_maps(true);
-    let _guard = settings.bind_to_scope();
-    assert_yaml_snapshot!(&map, @r###"
-    ---
-    a: first value
-    b: second value
-    c: third value
-    d: fourth value
-    "###);
+    {
+        let mut settings = Settings::new();
+        settings.set_sort_maps(true);
+        let _guard = settings.bind_to_scope();
+        assert_yaml_snapshot!(&map, @r###"
+        ---
+        a: first value
+        b: second value
+        c: third value
+        d: fourth value
+        "###);
+    }
+
+    assert!(!Settings::clone_current().sort_maps());
 }
 
 #[test]

--- a/tests/test_settings.rs
+++ b/tests/test_settings.rs
@@ -23,6 +23,7 @@ fn test_simple() {
 }
 
 #[test]
+#[allow(deprecated)]
 fn test_bound_to_thread() {
     let mut map = HashMap::new();
     map.insert("a", "first value");
@@ -33,6 +34,30 @@ fn test_bound_to_thread() {
     let mut settings = Settings::new();
     settings.set_sort_maps(true);
     settings.bind_to_thread();
+    assert_yaml_snapshot!(&map, @r###"
+    ---
+    a: first value
+    b: second value
+    c: third value
+    d: fourth value
+    "###);
+
+    // put defaults back
+    let settings = Settings::new();
+    settings.bind_to_thread();
+}
+
+#[test]
+fn test_bound_to_scope() {
+    let mut map = HashMap::new();
+    map.insert("a", "first value");
+    map.insert("b", "second value");
+    map.insert("c", "third value");
+    map.insert("d", "fourth value");
+
+    let mut settings = Settings::new();
+    settings.set_sort_maps(true);
+    let _guard = settings.bind_to_scope();
     assert_yaml_snapshot!(&map, @r###"
     ---
     a: first value


### PR DESCRIPTION
The current `Settings::bind_to_thread` is very hard to use as it has no resetting drop guard.