### PR TITLE
Create a smoother transition to new feature toggles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 all-features = true
 
 [features]
-default = ["colors"]
+default = ["colors", "legacy_default_serialization"]
 
 # when the redactions feature is enabled values can be redacted in serialized
 # snapshots.
@@ -47,6 +47,13 @@ json = ["serde_json", "serialization"]
 ron = ["dep_ron", "serialization"]
 toml = ["dep_toml", "serialization"]
 yaml = ["serde_yaml", "serialization"]
+
+# legacy support.  This is turned on by default for a single release and turns
+# on the assert_json_snapshot! and assert_yaml_snapshot! macros by default.
+# This will be phased out.  Use the "json" and "yaml" features instead.
+# If you already want to benefit of the leaner defaults, turn off the default
+# features and opt into what you want manually (you probably want to turn on "colors").
+legacy_default_serialization = ["serde_json", "serde_yaml", "serialization"]
 
 [dependencies]
 dep_csv = { package = "csv", version = "1.1.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@ pub mod _macro_support {
     pub use crate::env::get_cargo_workspace;
     pub use crate::runtime::{assert_snapshot, AutoName, ReferenceValue};
 
-    #[cfg(feature = "serde")]
+    #[cfg(feature = "serialization")]
     pub use crate::serialization::{serialize_value, SerializationFormat, SnapshotLocation};
 
     #[cfg(feature = "glob")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -142,7 +142,11 @@ macro_rules! assert_toml_snapshot {
 /// just use an empty string (`@""`).
 ///
 /// The snapshot name is optional but can be provided as first argument.
-#[cfg(feature = "yaml")]
+#[cfg_attr(
+    not(feature = "yaml"),
+    deprecated(note = "assert_yaml_snapshot! will require the \"yaml\" feature. \
+        Add the \"yaml\" feature to your Cargo.toml to silence this warning.")
+)]
 #[macro_export]
 macro_rules! assert_yaml_snapshot {
     ($value:expr, @$snapshot:literal) => {{
@@ -226,7 +230,11 @@ macro_rules! assert_ron_snapshot {
 /// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
-#[cfg(feature = "json")]
+#[cfg_attr(
+    not(feature = "json"),
+    deprecated(note = "assert_json_snapshot! will require the \"json\" feature. \
+        Add the \"json\" feature to your Cargo.toml to silence this warning.")
+)]
 #[macro_export]
 macro_rules! assert_json_snapshot {
     ($value:expr, @$snapshot:literal) => {{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -142,6 +142,7 @@ macro_rules! assert_toml_snapshot {
 /// just use an empty string (`@""`).
 ///
 /// The snapshot name is optional but can be provided as first argument.
+#[cfg(feature = "serialization")]
 #[cfg_attr(
     not(feature = "yaml"),
     deprecated(note = "assert_yaml_snapshot! will require the \"yaml\" feature. \
@@ -230,6 +231,7 @@ macro_rules! assert_ron_snapshot {
 /// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
+#[cfg(feature = "serialization")]
 #[cfg_attr(
     not(feature = "json"),
     deprecated(note = "assert_json_snapshot! will require the \"json\" feature. \

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -11,9 +11,9 @@ pub enum SerializationFormat {
     Ron,
     #[cfg(feature = "toml")]
     Toml,
-    #[cfg(feature = "yaml")]
+    // #[cfg(feature = "yaml")]
     Yaml,
-    #[cfg(feature = "json")]
+    // #[cfg(feature = "json")]
     Json,
 }
 
@@ -41,7 +41,7 @@ pub fn serialize_content(
     });
 
     match format {
-        #[cfg(feature = "yaml")]
+        // #[cfg(feature = "yaml")]
         SerializationFormat::Yaml => {
             let serialized = serde_yaml::to_string(&_content).unwrap();
             match _location {
@@ -49,7 +49,7 @@ pub fn serialize_content(
                 SnapshotLocation::File => serialized[4..].to_string(),
             }
         }
-        #[cfg(feature = "json")]
+        // #[cfg(feature = "json")]
         SerializationFormat::Json => serde_json::to_string_pretty(&_content).unwrap(),
         #[cfg(feature = "csv")]
         SerializationFormat::Csv => {


### PR DESCRIPTION
This turns on `assert_json_snapshot!` and `assert_yaml_snapshot!` by default again for one release but introduces a deprecation warning.

This fixes #259