### PR TITLE
Switch from serde_yaml to rust-yaml for serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,14 +47,14 @@ csv = ["dep_csv", "serialization"]
 json = ["serde_json", "serialization"]
 ron = ["dep_ron", "serialization"]
 toml = ["dep_toml", "serialization"]
-yaml = ["serde_yaml", "serialization"]
+yaml = ["serialization"]
 
 # legacy support.  This is turned on by default for a single release and turns
 # on the assert_json_snapshot! and assert_yaml_snapshot! macros by default.
 # This will be phased out.  Use the "json" and "yaml" features instead.
 # If you already want to benefit of the leaner defaults, turn off the default
 # features and opt into what you want manually (you probably want to turn on "colors").
-legacy_default_serialization = ["serde_json", "serde_yaml", "serialization"]
+legacy_default_serialization = ["serde_json", "serialization"]
 
 [dependencies]
 dep_csv = { package = "csv", version = "1.1.4", optional = true }
@@ -71,7 +71,6 @@ regex = { version = "1.6.0", default-features = false, optional = true, features
 yaml-rust = "0.4.5"
 serde = { version = "1.0.117", optional = true }
 serde_json = { version = "1.0.59", optional = true }
-serde_yaml = { version = "0.8.26", optional = true }
 linked-hash-map = "0.5.6"
 
 [dev-dependencies]

--- a/cargo-insta/Cargo.lock
+++ b/cargo-insta/Cargo.lock
@@ -32,12 +32,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,12 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,16 +236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "insta"
 version = "1.17.2"
 dependencies = [
@@ -268,7 +246,6 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "serde_yaml",
  "similar",
  "yaml-rust",
 ]
@@ -477,18 +454,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
 ]
 
 [[package]]

--- a/src/env.rs
+++ b/src/env.rs
@@ -119,7 +119,7 @@ pub fn get_cargo_workspace(manifest_dir: &str) -> Arc<PathBuf> {
             let docs =
                 yaml_rust::YamlLoader::load_from_str(std::str::from_utf8(&output.stdout).unwrap())
                     .unwrap();
-            let manifest = &docs[0];
+            let manifest = docs.get(0).expect("Unable to parse cargo manifest");
             let workspace_root = PathBuf::from(manifest["workspace_root"].as_str().unwrap());
             Arc::new(workspace_root)
         };


### PR DESCRIPTION
`serde_yaml` in 0.9 changed the output format and dropped `yaml-rust`. Since as of #255 we now use `yaml-rust` directly anyways we might as well shoot too birds with one stone. This avoids an extra dependency and it retains the same serialization format that we had before.

Fixes #256