### PR TITLE
Drop serde_json entirely for snapshot emission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ backtrace = []
 # TODO: This could be cleaner by using "dep:csv" without renaming the dep, but
 # this technique allows for a lower MSRV
 csv = ["dep_csv", "serialization"]
-json = ["serde_json", "serialization"]
+json = ["serialization"]
 ron = ["dep_ron", "serialization"]
 toml = ["dep_toml", "serialization"]
 yaml = ["serialization"]
@@ -54,7 +54,7 @@ yaml = ["serialization"]
 # This will be phased out.  Use the "json" and "yaml" features instead.
 # If you already want to benefit of the leaner defaults, turn off the default
 # features and opt into what you want manually (you probably want to turn on "colors").
-legacy_default_serialization = ["serde_json", "serialization"]
+legacy_default_serialization = ["serialization"]
 
 [dependencies]
 dep_csv = { package = "csv", version = "1.1.4", optional = true }
@@ -70,7 +70,6 @@ once_cell = "1.9.0"
 regex = { version = "1.6.0", default-features = false, optional = true, features = ["std", "unicode"] }
 yaml-rust = "0.4.5"
 serde = { version = "1.0.117", optional = true }
-serde_json = { version = "1.0.59", optional = true }
 linked-hash-map = "0.5.6"
 
 [dev-dependencies]

--- a/src/content/formats.rs
+++ b/src/content/formats.rs
@@ -2,11 +2,13 @@ use super::{Content, Error, Result};
 
 use yaml_rust::{yaml::Hash as YamlObj, Yaml as YamlValue};
 
-type BoxedResult<T> = std::result::Result<T, Box<dyn std::error::Error>>;
-
 impl Content {
-    pub(crate) fn as_json(&self) -> BoxedResult<String> {
-        Ok(crate::content::json::to_string(self))
+    pub(crate) fn as_json(&self) -> String {
+        crate::content::json::to_string(self)
+    }
+
+    pub(crate) fn as_json_pretty(&self) -> String {
+        crate::content::json::to_string_pretty(self)
     }
 
     // NOTE: Not implemented as `TryFrom<_>` because this is not generic and we want it to remain

--- a/src/content/json.rs
+++ b/src/content/json.rs
@@ -96,16 +96,16 @@ impl Serializer {
         match value {
             Content::Bool(true) => self.write_str("true"),
             Content::Bool(false) => self.write_str("false"),
-            Content::U8(n) => self.write_str(&n.to_string()),
-            Content::U16(n) => self.write_str(&n.to_string()),
-            Content::U32(n) => self.write_str(&n.to_string()),
-            Content::U64(n) => self.write_str(&n.to_string()),
-            Content::U128(n) => self.write_str(&n.to_string()),
-            Content::I8(n) => self.write_str(&n.to_string()),
-            Content::I16(n) => self.write_str(&n.to_string()),
-            Content::I32(n) => self.write_str(&n.to_string()),
-            Content::I64(n) => self.write_str(&n.to_string()),
-            Content::I128(n) => self.write_str(&n.to_string()),
+            Content::U8(n) => write!(self.out, "{}", n).unwrap(),
+            Content::U16(n) => write!(self.out, "{}", n).unwrap(),
+            Content::U32(n) => write!(self.out, "{}", n).unwrap(),
+            Content::U64(n) => write!(self.out, "{}", n).unwrap(),
+            Content::U128(n) => write!(self.out, "{}", n).unwrap(),
+            Content::I8(n) => write!(self.out, "{}", n).unwrap(),
+            Content::I16(n) => write!(self.out, "{}", n).unwrap(),
+            Content::I32(n) => write!(self.out, "{}", n).unwrap(),
+            Content::I64(n) => write!(self.out, "{}", n).unwrap(),
+            Content::I128(n) => write!(self.out, "{}", n).unwrap(),
             Content::F32(f) => {
                 if f.is_finite() {
                     self.write_str(&format_float(f));

--- a/src/content/json.rs
+++ b/src/content/json.rs
@@ -120,7 +120,7 @@ impl Serializer {
                     self.write_str("null")
                 }
             }
-            Content::Char(c) => self.write_escaped_str(&(*c as u32).to_string()),
+            Content::Char(c) => self.write_escaped_str(&(*c).to_string()),
             Content::String(s) => self.write_escaped_str(s),
             Content::Bytes(bytes) => {
                 self.start_container('[');
@@ -128,7 +128,7 @@ impl Serializer {
                     self.write_comma(idx == 0);
                     self.write_str(&byte.to_string());
                 }
-                self.start_container(']');
+                self.end_container(']', bytes.is_empty());
             }
             Content::None | Content::Unit | Content::UnitStruct(_) => self.write_str("null"),
             Content::Some(content) => self.serialize(content),
@@ -346,10 +346,22 @@ fn test_to_string_pretty_complex() {
             Content::from("unit_variant"),
             Content::UnitVariant("Stuff", 0, "value"),
         ),
-        (Content::from("u128"), Content::U128(42)),
-        (Content::from("f32"), Content::F32(42.0)),
-        (Content::from("f64"), Content::F64(42.0)),
+        (Content::from("u8"), Content::U8(8)),
+        (Content::from("u16"), Content::U16(16)),
+        (Content::from("u32"), Content::U32(32)),
+        (Content::from("u64"), Content::U64(64)),
+        (Content::from("u128"), Content::U128(128)),
+        (Content::from("i8"), Content::I8(8)),
+        (Content::from("i16"), Content::I16(16)),
+        (Content::from("i32"), Content::I32(32)),
+        (Content::from("i64"), Content::I64(64)),
+        (Content::from("i128"), Content::I128(128)),
+        (Content::from("f32"), Content::F32(32.0)),
+        (Content::from("f64"), Content::F64(64.0)),
+        (Content::from("char"), Content::Char('A')),
+        (Content::from("bytes"), Content::Bytes(b"hehe".to_vec())),
         (Content::from("null"), Content::None),
+        (Content::from("unit"), Content::Unit),
         (
             Content::from("crazy_string"),
             Content::String((0u8..=126).map(|x| x as char).collect()),
@@ -375,10 +387,27 @@ fn test_to_string_pretty_complex() {
         }
       ],
       "unit_variant": "value",
-      "u128": 42,
-      "f32": 42.0,
-      "f64": 42.0,
+      "u8": 8,
+      "u16": 16,
+      "u32": 32,
+      "u64": 64,
+      "u128": 128,
+      "i8": 8,
+      "i16": 16,
+      "i32": 32,
+      "i64": 64,
+      "i128": 128,
+      "f32": 32.0,
+      "f64": 64.0,
+      "char": "A",
+      "bytes": [
+        104,
+        101,
+        104,
+        101
+      ],
       "null": null,
+      "unit": null,
       "crazy_string": "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
     }
     "###);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -50,7 +50,7 @@ pub fn serialize_content(
             }
         }
         // #[cfg(feature = "json")]
-        SerializationFormat::Json => serde_json::to_string_pretty(&_content).unwrap(),
+        SerializationFormat::Json => _content.as_json_pretty(),
         #[cfg(feature = "csv")]
         SerializationFormat::Csv => {
             let mut buf = Vec::with_capacity(128);

--- a/src/serialization.rs
+++ b/src/serialization.rs
@@ -11,9 +11,7 @@ pub enum SerializationFormat {
     Ron,
     #[cfg(feature = "toml")]
     Toml,
-    // #[cfg(feature = "yaml")]
     Yaml,
-    // #[cfg(feature = "json")]
     Json,
 }
 
@@ -23,34 +21,32 @@ pub enum SnapshotLocation {
 }
 
 pub fn serialize_content(
-    mut _content: Content,
+    mut content: Content,
     format: SerializationFormat,
-    _location: SnapshotLocation,
+    location: SnapshotLocation,
 ) -> String {
-    _content = Settings::with(|settings| {
+    content = Settings::with(|settings| {
         if settings.sort_maps() {
-            _content.sort_maps();
+            content.sort_maps();
         }
         #[cfg(feature = "redactions")]
         {
             for (selector, redaction) in settings.iter_redactions() {
-                _content = selector.redact(_content, redaction);
+                content = selector.redact(content, redaction);
             }
         }
-        _content
+        content
     });
 
     match format {
-        // #[cfg(feature = "yaml")]
         SerializationFormat::Yaml => {
-            let serialized = _content.as_yaml();
-            match _location {
+            let serialized = content.as_yaml();
+            match location {
                 SnapshotLocation::Inline => serialized,
                 SnapshotLocation::File => serialized[4..].to_string(),
             }
         }
-        // #[cfg(feature = "json")]
-        SerializationFormat::Json => _content.as_json_pretty(),
+        SerializationFormat::Json => content.as_json_pretty(),
         #[cfg(feature = "csv")]
         SerializationFormat::Csv => {
             let mut buf = Vec::with_capacity(128);
@@ -58,12 +54,12 @@ pub fn serialize_content(
                 let mut writer = dep_csv::Writer::from_writer(&mut buf);
                 // if the top-level content we're serializing is a vector we
                 // want to serialize it multiple times once for each item.
-                if let Some(content_slice) = _content.as_slice() {
+                if let Some(content_slice) = content.as_slice() {
                     for content in content_slice {
                         writer.serialize(content).unwrap();
                     }
                 } else {
-                    writer.serialize(&_content).unwrap();
+                    writer.serialize(&content).unwrap();
                 }
                 writer.flush().unwrap();
             }
@@ -85,12 +81,12 @@ pub fn serialize_content(
                 dep_ron::options::Options::default(),
             )
             .unwrap();
-            _content.serialize(&mut serializer).unwrap();
+            content.serialize(&mut serializer).unwrap();
             String::from_utf8(buf).unwrap()
         }
         #[cfg(feature = "toml")]
         SerializationFormat::Toml => {
-            let mut rv = dep_toml::to_string_pretty(&_content).unwrap();
+            let mut rv = dep_toml::to_string_pretty(&content).unwrap();
             if rv.ends_with('\n') {
                 rv.truncate(rv.len() - 1);
             }

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -69,7 +69,7 @@ impl PendingInlineSnapshot {
 
     pub fn save<P: AsRef<Path>>(&self, p: P) -> Result<(), Box<dyn Error>> {
         let mut f = fs::OpenOptions::new().create(true).append(true).open(p)?;
-        let mut s = self.as_content().as_json()?;
+        let mut s = self.as_content().as_json();
         s.push('\n');
         f.write_all(s.as_bytes())?;
         Ok(())


### PR DESCRIPTION
This removes `serde_json` for a built-in emitter. This gives us more stable snapshots but this still needs tests to ensure the output matches what was there before.

Fixes #258 