### PR TITLE
feat: add support for compression of the snap files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ ron = ["dep_ron", "serde"]
 toml = ["dep_toml", "serde"]
 yaml = ["serde"]
 
+# compress the snap files
+compression = ["lzma-rs", "tempfile"]
+
 [dependencies]
 dep_csv = { package = "csv", version = "1.1.4", optional = true }
 console = { version = "0.15.1", optional = true, default-features = false }
@@ -58,6 +61,8 @@ regex = { version = "1.6.0", default-features = false, optional = true, features
 yaml-rust = "0.4.5"
 serde = { version = "1.0.117", optional = true }
 linked-hash-map = "0.5.6"
+lzma-rs = { version = "0.2.0", optional = true }
+tempfile = { version = "3.3.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.117", features = ["derive"] }


### PR DESCRIPTION
## Description

This PR adds support for compression/decompression of the snap files. It compresses the snap file whenever they are saved and decompresses them whenever they are read.

## Rationale 

My snap files are usually pretty large (thousands of lines of code), and adding them to the git repository pollutes the dev experience. I think it would be nice to maintain the compressed version of the snap files under the snapshot folder. This feature allows that.

The `"compression"` feature can be enabled through Cargo.

Fixes #278 