### PR TITLE
Add nextest support to cargo-insta

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -513,23 +513,9 @@ fn detect_test_runner(preference: Option<&str>) -> Result<TestRunner, Box<dyn Er
         .or_else(|| env::var("INSTA_TEST_RUNNER").ok().map(Cow::Owned))
         .unwrap_or(Cow::Borrowed("auto"));
 
-    // if preference is auto check if "cargo nextest" executes the help page with status code 0
     match &preference as &str {
-        "auto" => Ok(
-            if std::process::Command::new("cargo")
-                .arg("nextest")
-                .arg("--help")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .map_or(false, |x| x.success())
-            {
-                TestRunner::Nextest
-            } else {
-                TestRunner::CargoTest
-            },
-        ),
-        "cargo-test" => Ok(TestRunner::CargoTest),
+        // auto for now defaults to cargo-test still
+        "auto" | "cargo-test" => Ok(TestRunner::CargoTest),
         "nextest" => Ok(TestRunner::Nextest),
         _ => Err(err_msg("invalid test runner preference")),
     }


### PR DESCRIPTION
This adds a `INSTA_TEST_RUNNER` environment variable to control if `cargo-test` or `nextest` should be used.  The default is `auto` which will eventually prefer `nextest` over `cargo-test` but for now stays with `cargo-test`.

It still needs to use `cargo test --doc` to run doctests due to https://github.com/nextest-rs/nextest/issues/16

Refs #282