### PR TITLE
Only print warning if no snapshots found

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -400,8 +400,6 @@ fn process_snapshots(cmd: ProcessCommand, op: Option<Operation>) -> Result<(), B
             }
         }
         return Ok(());
-    } else if !loc.no_ignore {
-        println!("{}: {}", style("info").bold(), IGNORE_MESSAGE);
     }
 
     let mut accepted = vec![];


### PR DESCRIPTION
A very incomplete solution to https://github.com/mitsuhiko/insta/issues/319. 

Until we can agree on a good path forward, this seems like a good tradeoff, given the likelihood that someone has a subset of snap files being gitignored, vs. every standard run of `cargo-insta`. 

But totally fine to close if you don't agree @mitsuhiko