### PR TITLE
Implement basic tool config

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,13 +1,25 @@
 use std::collections::BTreeMap;
-use std::io::Write;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::{env, fs};
 
+use crate::content::{yaml, Content};
 use crate::utils::is_ci;
 
 lazy_static::lazy_static! {
     static ref WORKSPACES: Mutex<BTreeMap<String, Arc<PathBuf>>> = Mutex::new(BTreeMap::new());
+    static ref TOOL_CONFIGS: Mutex<BTreeMap<String, Arc<ToolConfig>>> = Mutex::new(BTreeMap::new());
+}
+
+pub fn get_tool_config(manifest_dir: &str) -> Arc<ToolConfig> {
+    let mut configs = TOOL_CONFIGS.lock().unwrap();
+    if let Some(rv) = configs.get(manifest_dir) {
+        return rv.clone();
+    }
+    let config = Arc::new(ToolConfig::load(manifest_dir));
+    configs.insert(manifest_dir.to_string(), config.clone());
+    config
 }
 
 /// How snapshots are supposed to be updated
@@ -34,56 +46,114 @@ pub enum OutputBehavior {
     Nothing,
 }
 
-/// Is insta told to force update snapshots?
-pub fn force_update_snapshots() -> bool {
-    match env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").ok().as_deref() {
-        None | Some("") | Some("0") => false,
-        Some("1") => true,
-        _ => panic!("invalid value for INSTA_FORCE_UPDATE_SNAPSHOTS"),
-    }
+/// Represents a tool configuration.
+#[derive(Debug)]
+pub struct ToolConfig {
+    values: Content,
 }
 
-/// Is insta instructed to fail in tests?
-pub fn force_pass() -> bool {
-    match env::var("INSTA_FORCE_PASS").ok().as_deref() {
-        None | Some("") | Some("0") => false,
-        Some("1") => true,
-        _ => panic!("invalid value for INSTA_FORCE_PASS"),
-    }
-}
-
-/// Returns the intended output behavior for insta.
-pub fn get_output_behavior() -> OutputBehavior {
-    match env::var("INSTA_OUTPUT").ok().as_deref() {
-        None | Some("") | Some("diff") => OutputBehavior::Diff,
-        Some("summary") => OutputBehavior::Summary,
-        Some("minimal") => OutputBehavior::Minimal,
-        Some("none") => OutputBehavior::Nothing,
-        _ => panic!("invalid value for INSTA_OUTPUT"),
-    }
-}
-
-/// Returns the intended snapshot update behavior.
-pub fn get_snapshot_update_behavior(unseen: bool) -> SnapshotUpdate {
-    match env::var("INSTA_UPDATE").ok().as_deref() {
-        None | Some("") | Some("auto") => {
-            if is_ci() {
-                SnapshotUpdate::NoUpdate
-            } else {
-                SnapshotUpdate::NewFile
+impl ToolConfig {
+    /// Loads the tool config for a specific manifest.
+    pub fn load(manifest_dir: &str) -> ToolConfig {
+        let cargo_workspace = get_cargo_workspace(manifest_dir);
+        let path = cargo_workspace.join(".config/insta.yaml");
+        let values = match fs::read_to_string(path) {
+            Ok(s) => yaml::parse_str(&s).expect("failed to deserialize tool config"),
+            Err(err) if matches!(err.kind(), io::ErrorKind::NotFound) => {
+                Content::Map(Default::default())
             }
+            Err(err) => panic!("failed to read tool config: {}", err),
+        };
+        ToolConfig { values }
+    }
+
+    fn resolve(&self, path: &[&str]) -> Option<&Content> {
+        path.iter()
+            .try_fold(&self.values, |node, segment| match node.resolve_inner() {
+                Content::Map(fields) => fields
+                    .iter()
+                    .find(|x| x.0.as_str() == Some(segment))
+                    .map(|x| &x.1),
+                Content::Struct(_, fields) | Content::StructVariant(_, _, _, fields) => {
+                    fields.iter().find(|x| x.0 == *segment).map(|x| &x.1)
+                }
+                _ => None,
+            })
+    }
+
+    fn get_bool(&self, path: &[&str]) -> Option<bool> {
+        self.resolve(path).and_then(|x| x.as_bool())
+    }
+
+    fn get_str(&self, path: &[&str]) -> Option<&str> {
+        self.resolve(path).and_then(|x| x.as_str())
+    }
+
+    /// Is insta told to force update snapshots?
+    pub fn force_update_snapshots(&self) -> bool {
+        match env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").ok().as_deref() {
+            None | Some("") => self
+                .get_bool(&["snapshots", "force_update"])
+                .unwrap_or(false),
+            Some("0") => false,
+            Some("1") => true,
+            _ => panic!("invalid value for INSTA_FORCE_UPDATE_SNAPSHOTS"),
         }
-        Some("always") | Some("1") => SnapshotUpdate::InPlace,
-        Some("new") => SnapshotUpdate::NewFile,
-        Some("unseen") => {
-            if unseen {
-                SnapshotUpdate::NewFile
-            } else {
-                SnapshotUpdate::InPlace
+    }
+
+    /// Is insta instructed to fail in tests?
+    pub fn force_pass(&self) -> bool {
+        match env::var("INSTA_FORCE_PASS").ok().as_deref() {
+            None | Some("") => self.get_bool(&["behavior", "force_pass"]).unwrap_or(false),
+            Some("0") => false,
+            Some("1") => true,
+            _ => panic!("invalid value for INSTA_FORCE_PASS"),
+        }
+    }
+
+    /// Returns the intended output behavior for insta.
+    pub fn get_output_behavior(&self) -> OutputBehavior {
+        let env_var = env::var("INSTA_OUTPUT").ok();
+        let val = match env_var.as_deref() {
+            None | Some("") => self.get_str(&["behavior", "output"]).unwrap_or("diff"),
+            Some(val) => val,
+        };
+        match val {
+            "diff" => OutputBehavior::Diff,
+            "summary" => OutputBehavior::Summary,
+            "minimal" => OutputBehavior::Minimal,
+            "none" => OutputBehavior::Nothing,
+            _ => panic!("invalid value for INSTA_OUTPUT"),
+        }
+    }
+
+    /// Returns the intended snapshot update behavior.
+    pub fn get_snapshot_update_behavior(&self, unseen: bool) -> SnapshotUpdate {
+        let env_var = env::var("INSTA_UPDATE").ok();
+        let val = match env_var.as_deref() {
+            None | Some("") => self.get_str(&["behavior", "update"]).unwrap_or("auto"),
+            Some(val) => val,
+        };
+        match val {
+            "auto" => {
+                if is_ci() {
+                    SnapshotUpdate::NoUpdate
+                } else {
+                    SnapshotUpdate::NewFile
+                }
             }
+            "always" | "1" => SnapshotUpdate::InPlace,
+            "new" => SnapshotUpdate::NewFile,
+            "unseen" => {
+                if unseen {
+                    SnapshotUpdate::NewFile
+                } else {
+                    SnapshotUpdate::InPlace
+                }
+            }
+            "no" => SnapshotUpdate::NoUpdate,
+            _ => panic!("invalid value for INSTA_UPDATE"),
         }
-        Some("no") => SnapshotUpdate::NoUpdate,
-        _ => panic!("invalid value for INSTA_UPDATE"),
     }
 }
 

--- a/src/glob.rs
+++ b/src/glob.rs
@@ -5,6 +5,7 @@ use std::sync::Mutex;
 use globset::{GlobBuilder, GlobMatcher};
 use walkdir::WalkDir;
 
+use crate::env::get_tool_config;
 use crate::settings::Settings;
 use crate::utils::style;
 
@@ -37,7 +38,7 @@ lazy_static::lazy_static! {
     };
 }
 
-pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) {
+pub fn glob_exec<F: FnMut(&Path)>(manifest_dir: &str, base: &Path, pattern: &str, mut f: F) {
     let glob = GlobBuilder::new(pattern)
         .case_insensitive(true)
         .literal_separator(true)
@@ -52,7 +53,7 @@ pub fn glob_exec<F: FnMut(&Path)>(base: &Path, pattern: &str, mut f: F) {
     GLOB_STACK.lock().unwrap().push(GlobCollector {
         failed: 0,
         show_insta_hint: false,
-        fail_fast: std::env::var("INSTA_GLOB_FAIL_FAST").as_deref() == Ok("1"),
+        fail_fast: get_tool_config(manifest_dir).glob_fail_fast(),
     });
 
     // step 1: collect all matching files

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,11 @@
 //!   update: "auto" | "always" | "new" | "unseen" | "no"
 //!   # also set by INSTA_GLOB_FAIL_FAST
 //!   glob_fail_fast: true/false
+//!
+//! # these are used by cargo insta test
+//! test:
+//!   # also set by INSTA_TEST_RUNNER
+//!   runner: "auto" | "cargo-test" | "nextest"
 //! ```
 //!
 //! # Optional: Faster Runs
@@ -271,6 +276,7 @@ pub mod internals {
 // exported for cargo-insta only
 #[doc(hidden)]
 pub mod _cargo_insta_support {
+    pub use crate::env::{OutputBehavior, SnapshotUpdate, TestRunner, ToolConfig};
     pub use crate::{
         output::{print_snapshot, print_snapshot_diff},
         snapshot::PendingInlineSnapshot,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,27 @@
 //! # Settings
 //!
 //! There are some settings that can be changed on a per-thread (and thus
-//! per-test) basis.  For more information see [Settings].
+//! per-test) basis.  For more information see [Settings].  Additionally
+//! there is a insta [tool config](#tool-config) for global settings.
+//!
+//! # Tool Config
+//!
+//! Insta will load a file `.config/insta.yaml` with settings that change the
+//! behavior of insta between runs.  The following config variables exist:
+//!
+//! ```yaml
+//! behavior:
+//!   # also set by INSTA_FORCE_UPDATE
+//!   force_update: true/false
+//!   # also set by INSTA_FORCE_PASS
+//!   force_pass: true/false
+//!   # also set by INSTA_OUTPUT
+//!   output: "diff" | "summary" | "minimal" | "none"
+//!   # also set by INSTA_UPDATE
+//!   update: "auto" | "always" | "new" | "unseen" | "no"
+//!   # also set by INSTA_GLOB_FAIL_FAST
+//!   glob_fail_fast: true/false
+//! ```
 //!
 //! # Optional: Faster Runs
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -549,6 +549,6 @@ macro_rules! glob {
             .unwrap()
             .canonicalize()
             .unwrap_or_else(|e| panic!("failed to canonicalize insta::glob! base path: {}", e));
-        $crate::_macro_support::glob_exec(&base, $glob, $closure);
+        $crate::_macro_support::glob_exec(env!("CARGO_MANIFEST_DIR"), &base, $glob, $closure);
     }};
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,8 +8,8 @@ use std::str;
 use std::sync::{Arc, Mutex};
 
 use crate::env::{
-    get_cargo_workspace, get_tool_config, memoize_snapshot_file, OutputBehavior,
-    SnapshotUpdateBehavior, ToolConfig,
+    get_cargo_workspace, get_tool_config, memoize_snapshot_file, snapshot_update_behavior,
+    OutputBehavior, SnapshotUpdateBehavior, ToolConfig,
 };
 use crate::output::{print_snapshot_diff_with_title, print_snapshot_summary_with_title};
 use crate::settings::Settings;
@@ -351,7 +351,7 @@ impl<'a> SnapshotAssertionContext<'a> {
             .as_ref()
             .map_or(false, |x| fs::metadata(x).is_ok());
         let should_print = self.tool_config.output_behavior() != OutputBehavior::Nothing;
-        let snapshot_update = self.tool_config.snapshot_update_behavior(unseen);
+        let snapshot_update = snapshot_update_behavior(&self.tool_config, unseen);
 
         match snapshot_update {
             SnapshotUpdateBehavior::InPlace => {


### PR DESCRIPTION
This changes the insta and cargo-insta internals so that a tool config is loaded from `.config/insta.yaml`.

Fixes #282 