### PR TITLE
Add ways to walk into hidden folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Added an insta tool config (`.config/insta.yaml`) to change the
   behavior of insta and cargo-insta. (#322)
+- Renamed `--no-ignore` to `--include-ignored`.
+- Added `--include-hidden` to instruct insta to also walk into
+  hidden paths.
 
 ## 1.23.0
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -96,6 +96,10 @@ pub struct ToolConfig {
     auto_review: bool,
     #[cfg(feature = "_cargo_insta_internal")]
     auto_accept_unseen: bool,
+    #[cfg(feature = "_cargo_insta_internal")]
+    review_include_ignored: bool,
+    #[cfg(feature = "_cargo_insta_internal")]
+    review_include_hidden: bool,
 }
 
 impl ToolConfig {
@@ -199,6 +203,14 @@ impl ToolConfig {
             auto_accept_unseen: resolve(&cfg, &["test", "auto_accept_unseen"])
                 .and_then(|x| x.as_bool())
                 .unwrap_or(false),
+            #[cfg(feature = "_cargo_insta_internal")]
+            review_include_hidden: resolve(&cfg, &["review", "include_hidden"])
+                .and_then(|x| x.as_bool())
+                .unwrap_or(false),
+            #[cfg(feature = "_cargo_insta_internal")]
+            review_include_ignored: resolve(&cfg, &["test", "include_ignored"])
+                .and_then(|x| x.as_bool())
+                .unwrap_or(false),
         })
     }
 
@@ -244,6 +256,14 @@ impl ToolConfig {
     /// Returns the auto accept unseen flag.
     pub fn auto_accept_unseen(&self) -> bool {
         self.auto_accept_unseen
+    }
+
+    pub fn review_include_hidden(&self) -> bool {
+        self.review_include_hidden
+    }
+
+    pub fn review_include_ignored(&self) -> bool {
+        self.review_include_ignored
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,13 @@
 //!   auto_review: true/false
 //!   # automatically assume --accept-unseen was passed to cargo insta test
 //!   auto_accept_unseen: true/false
+//!
+//! # these are used by cargo insta review
+//! review:
+//!   # also look for snapshots in ignored folders
+//!   include_ignored: true / false
+//!   # also look for snapshots in hidden folders
+//!   include_hidden: true / false
 //! ```
 //!
 //! # Optional: Faster Runs


### PR DESCRIPTION
This renames the confusing `--no-ignore` to `--include-ignored` and adds a new `--include-hidden` flag. The latter is used to instruct insta to walk into hidden folders. Additionally both are now also available as tool config.

Refs #326