### PR TITLE
Improve `cargo insta help` output

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -183,8 +183,8 @@ pub struct TestCommand {
     #[structopt(short = "Q", long)]
     pub no_quiet: bool,
     /// Picks the test runner.
-    #[structopt(long)]
-    pub test_runner: Option<String>,
+    #[structopt(long, default_value="auto", possible_values=&["auto", "cargo-test", "nextest"])]
+    pub test_runner: String,
     /// Options passed to cargo test
     // Sets raw to true so that `--` is required
     #[structopt(name = "CARGO_TEST_ARGS", raw(true))]
@@ -528,12 +528,10 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
         cmd.unreferenced = "delete".into();
     }
 
-    let test_runner = match cmd.test_runner {
-        Some(ref test_runner) => test_runner
-            .parse()
-            .map_err(|_| err_msg("invalid test runner preference"))?,
-        None => loc.tool_config.test_runner(),
-    };
+    let test_runner = cmd
+        .test_runner
+        .parse()
+        .map_err(|_| err_msg("invalid test runner preference"))?;
 
     let unreferenced = cmd
         .unreferenced

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -32,9 +32,9 @@ use crate::walk::{find_snapshots, make_deletion_walker, make_snapshot_walker, Fi
     global_setting = AppSettings::DontCollapseArgsInUsage
 )]
 pub struct Opts {
-    /// Coloring: auto, always, never
-    #[structopt(long, global = true, value_name = "WHEN")]
-    pub color: Option<String>,
+    /// Coloring
+    #[structopt(long, global = true, value_name = "WHEN", default_value="auto", possible_values=&["auto", "always", "never"])]
+    pub color: String,
 
     #[structopt(subcommand)]
     pub command: Command,
@@ -984,8 +984,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
 
     let opts = Opts::from_iter(args);
 
-    let color = opts.color.as_ref().map(|x| x.as_str()).unwrap_or("auto");
-    handle_color(color)?;
+    handle_color(&opts.color)?;
     match opts.command {
         Command::Review(ref cmd) | Command::Accept(ref cmd) | Command::Reject(ref cmd) => {
             process_snapshots(
@@ -1000,7 +999,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
                 },
             )
         }
-        Command::Test(cmd) => test_run(cmd, color),
+        Command::Test(cmd) => test_run(cmd, &opts.color),
         Command::Show(cmd) => show_cmd(cmd),
         Command::PendingSnapshots(cmd) => pending_snapshots_cmd(cmd),
     }

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -41,7 +41,10 @@ pub struct Opts {
 }
 
 #[derive(StructOpt, Debug)]
-#[structopt(bin_name = "cargo insta")]
+#[structopt(
+    bin_name = "cargo insta",
+    after_help = "For the online documentation of the latest version, see https://insta.rs/docs/cli/."
+)]
 pub enum Command {
     /// Interactively review snapshots
     #[structopt(name = "review", alias = "verify")]


### PR DESCRIPTION
If we would bump the MSRV to 1.64.0 we could switch from structopt to clap, which would let us further improve the `cargo insta help test` output by grouping options with the `help_heading` option (see https://github.com/charliermarsh/ruff/pull/2155 for an example) ... and then we could also have the `TestRunner` and `UnreferencedSnapshots` enums derive [ValueEnum](https://docs.rs/clap/latest/clap/trait.ValueEnum.html), which would mean we would no longer have to duplicate the `possible_values` in `cargo-insta`.

But seeing that you haven't yet decided on the MSRV issue #289, I just made the improvements that structopt supports :)