### PR TITLE
Add support for allow_duplicates!

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -8,7 +8,7 @@ use std::{io, process};
 use console::{set_colors_enabled, style, Key, Term};
 use insta::Snapshot;
 use insta::_cargo_insta_support::{
-    is_ci, print_snapshot, print_snapshot_diff, SnapshotUpdate, TestRunner, ToolConfig,
+    is_ci, print_snapshot, SnapshotPrinter, SnapshotUpdate, TestRunner, ToolConfig,
     UnreferencedSnapshots,
 };
 use serde::Serialize;
@@ -246,7 +246,10 @@ fn query_snapshot(
             pkg_version,
         );
 
-        print_snapshot_diff(workspace_root, new, old, snapshot_file, line, *show_info);
+        let mut printer = SnapshotPrinter::new(workspace_root, old, new);
+        printer.set_snapshot_file(snapshot_file);
+        printer.set_line(line);
+        printer.set_show_info(*show_info);
 
         println!();
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ pub mod _cargo_insta_support {
             Error as ToolConfigError, OutputBehavior, SnapshotUpdate, TestRunner, ToolConfig,
             UnreferencedSnapshots,
         },
-        output::{print_snapshot, print_snapshot_diff},
+        output::{print_snapshot, SnapshotPrinter},
         snapshot::PendingInlineSnapshot,
         snapshot::SnapshotContents,
         utils::is_ci,
@@ -311,7 +311,7 @@ pub use crate::redaction::{dynamic_redaction, sorted_redaction};
 pub mod _macro_support {
     pub use crate::content::Content;
     pub use crate::env::get_cargo_workspace;
-    pub use crate::runtime::{assert_snapshot, AutoName, ReferenceValue};
+    pub use crate::runtime::{assert_snapshot, with_allow_duplicates, AutoName, ReferenceValue};
 
     #[cfg(feature = "serde")]
     pub use crate::serialization::{serialize_value, SerializationFormat, SnapshotLocation};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -554,3 +554,26 @@ macro_rules! glob {
         $crate::_macro_support::glob_exec(env!("CARGO_MANIFEST_DIR"), &base, $glob, $closure);
     }};
 }
+
+/// Utility macro to create a multi-snapshot run where all snapshots match.
+///
+/// Within this block, insta will allow an assertion to be run twice (even inline) without
+/// generating another snapshot.  Instead it will assert that snapshot expressions visited
+/// more than once are matching.
+///
+/// ```rust
+/// insta::allow_duplicates! {
+///     for x in (0..10).step_by(2) {
+///         let is_even = x % 2 == 0;
+///         insta::assert_debug_snapshot!(is_even, @"true");
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! allow_duplicates {
+    ($($x:tt)*) => {
+        $crate::_macro_support::with_allow_duplicates(|| {
+            $($x)*
+        })
+    }
+}

--- a/tests/test_allow_duplicates.rs
+++ b/tests/test_allow_duplicates.rs
@@ -1,0 +1,22 @@
+use insta::{allow_duplicates, assert_debug_snapshot};
+
+#[test]
+fn test_basic_duplicates_passes() {
+    allow_duplicates! {
+        for x in (0..10).step_by(2) {
+            let is_even = x % 2 == 0;
+            assert_debug_snapshot!(is_even, @"true");
+        }
+    }
+}
+
+#[test]
+#[should_panic = "snapshot assertion for 'basic_duplicates_assertion_failed' failed in line"]
+fn test_basic_duplicates_assertion_failed() {
+    allow_duplicates! {
+        for x in (0..10).step_by(3) {
+            let is_even = x % 2 == 0;
+            assert_debug_snapshot!(is_even, @"true");
+        }
+    }
+}


### PR DESCRIPTION
This adds a new macro called `allow_duplicates!`. When a block of code is wrapped with it, every snapshot assertion can be visited more than once. In that case all of the snapshot assertions in a loop etc. have to match with each other and if not, an assertion error is raised.

Motivational example:

```rust
#[test]
fn test_basic_duplicates_passes() {
    allow_duplicates! {
        for x in (0..10).step_by(2) {
            let is_even = x % 2 == 0;
            assert_debug_snapshot!(is_even, @"true");
        }
    }
}
```

Fixes #313 