### PR TITLE
glob!: Add three-arg version to specify base_path

### DIFF
--- a/tests/glob_submodule/mod.rs
+++ b/tests/glob_submodule/mod.rs
@@ -1,0 +1,53 @@
+#![cfg(feature = "glob")]
+
+#[test]
+fn test_basic_globbing_parent_dir() {
+    insta::glob!("../inputs", "*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_json_snapshot!(&contents);
+    });
+}
+
+#[test]
+fn test_basic_globbing_nested_parent_dir_base_path() {
+    insta::glob!("../inputs-nested", "*/*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_snapshot!(&contents);
+    });
+}
+
+#[test]
+fn test_basic_globbing_nested_parent_glob() {
+    insta::glob!("..", "inputs-nested/*/*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_snapshot!(&contents);
+    });
+}
+
+#[test]
+fn test_globs_follow_links_parent_dir_base_path() {
+    insta::glob!("../link-to-inputs", "*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_json_snapshot!(&contents);
+    });
+}
+
+#[test]
+fn test_globs_follow_links_parent_dir_glob() {
+    insta::glob!("..", "link-to-inputs/*.txt", |path| {
+        let contents = std::fs::read_to_string(path).unwrap();
+        insta::assert_json_snapshot!(&contents);
+    });
+}
+
+#[test]
+fn test_basic_globbing_absolute_dir() {
+    insta::glob!(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/inputs"),
+        "*.txt",
+        |path| {
+            let contents = std::fs::read_to_string(path).unwrap();
+            insta::assert_json_snapshot!(&contents);
+        }
+    );
+}

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_absolute_dir@goodbye.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_absolute_dir@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_absolute_dir@hello.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_absolute_dir@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_dir_base_path@a__file.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_dir_base_path@a__file.txt.snap
@@ -1,0 +1,7 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs-nested/a/file.txt
+---
+Hello A
+

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_dir_base_path@b__file.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_dir_base_path@b__file.txt.snap
@@ -1,0 +1,7 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs-nested/b/file.txt
+---
+Hello B
+

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_glob@a__file.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_glob@a__file.txt.snap
@@ -1,0 +1,7 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs-nested/a/file.txt
+---
+Hello A
+

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_glob@b__file.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_nested_parent_glob@b__file.txt.snap
@@ -1,0 +1,7 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs-nested/b/file.txt
+---
+Hello B
+

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_parent_dir@goodbye.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_parent_dir@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_parent_dir@hello.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__basic_globbing_parent_dir@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_base_path@goodbye.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_base_path@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_base_path@hello.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_base_path@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_glob@goodbye.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_glob@goodbye.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/goodbye.txt
+---
+"Contents of goodbye"

--- a/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_glob@hello.txt.snap
+++ b/tests/glob_submodule/snapshots/test_glob__glob_submodule__globs_follow_links_parent_dir_glob@hello.txt.snap
@@ -1,0 +1,6 @@
+---
+source: tests/glob_submodule/mod.rs
+expression: "&contents"
+input_file: tests/inputs/hello.txt
+---
+"Contents of hello"

--- a/tests/test_glob.rs
+++ b/tests/test_glob.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "glob")]
 
+mod glob_submodule;
+
 #[test]
 fn test_basic_globbing() {
     insta::glob!("inputs/*.txt", |path| {


### PR DESCRIPTION
The new three-arg glob! allows users to specify the base directory the glob is working against. This works around the limitation that blobs like `../foo/*.json` do not resolve with the current walkdir + globset implementation.

This allows the usage of `glob!` in nested situations where the globbed files are in a parent directory:

```
src
├── main.rs
├── snapshots
│   └── insta_glob_test__insta_glob_dir.snap
├── submod
│   └── mod.rs -- glob! tests are here
└── test_data
    └── foo.json
```

```rust
glob!("../test_data", "*.json", |path| { ... })
```