### PR TITLE
Pin CSV to 1.1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ yaml = ["serde"]
 _cargo_insta_internal = []
 
 [dependencies]
-dep_csv = { package = "csv", version = "1.1.4", optional = true }
+dep_csv = { package = "csv", version = "=1.1.6", optional = true }
 console = { version = "0.15.4", optional = true, default-features = false }
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }


### PR DESCRIPTION
CSV now requires 1.60, trying to see if pinning to 1.1.6 works to retain lower MSRV.