### PR TITLE
Simpler accept behavior on non-insta failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.30.0
+
+- Snapshots are accepted when running with `--accept` even if a test outside
+  insta fails.
+
 ## 1.29.0
 
-- Fixed a rednering bug with snapshot display (lines were not
+- Fixed a rendering bug with snapshot display (lines were not
   rendered to the terminal width).
 
 ## 1.28.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.30.0
 
 - Snapshots are accepted when running with `--accept` even if a test outside
-  insta fails.
+  insta fails.  (#358)
 -  Write inline snapshots with atomic rename to avoid some rare races.  (#373)
 -  Pass `--color=...` to libtest to propagate color choices in more situations.  (#375)
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -607,13 +607,11 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
         success = success && proc.status()?.success();
     }
 
-    if !success {
-        if cmd.review {
-            eprintln!(
-                "{} non snapshot tests failed, skipping review",
-                style("warning:").bold().yellow()
-            );
-        }
+    if !success && cmd.review {
+        eprintln!(
+            "{} non snapshot tests failed, skipping review",
+            style("warning:").bold().yellow()
+        );
         return Err(QuietExit(1).into());
     }
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -601,11 +601,6 @@ fn test_run(mut cmd: TestCommand, color: &str) -> Result<(), Box<dyn Error>> {
                 "{} non snapshot tests failed, skipping review",
                 style("warning:").bold().yellow()
             );
-        } else if cmd.accept {
-            eprintln!(
-                "{} non snapshot tests failed, not accepted changes",
-                style("warning:").bold().yellow()
-            );
         }
         return Err(QuietExit(1).into());
     }


### PR DESCRIPTION
I wasn't sure how deliberate this choice was -- totally fine to close if it was. 

As a user, I always want it to honor the `--accept` arg.