### PR TITLE
Inherit `color` behavior from `CARGO_TERM_COLOR` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.30.0 [unreleased]
+
+- Inherit `color` option from a `CARGO_TERM_COLOR` environment variable (#361)
+
 ## 1.29.0
 
 - Fixed a rednering bug with snapshot display (lines were not
@@ -43,7 +47,7 @@ All notable changes to insta and cargo-insta are documented here.
 ## 1.24.1
 
 - Fix non working `--include-hidden` flag (#331)
-- Fix incorrect mapping of `review.include_ignored` (#330) 
+- Fix incorrect mapping of `review.include_ignored` (#330)
 
 ## 1.24.0
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -32,7 +32,7 @@ use crate::walk::{find_snapshots, make_deletion_walker, make_snapshot_walker, Fi
 )]
 pub struct Opts {
     /// Coloring
-    #[structopt(long, global = true, value_name = "WHEN", default_value="auto", possible_values=&["auto", "always", "never"])]
+    #[structopt(long, global = true, value_name = "WHEN", default_value="auto", possible_values=&["auto", "always", "never"], env = "CARGO_TERM_COLOR")]
     pub color: String,
 
     #[structopt(subcommand)]


### PR DESCRIPTION
ref https://doc.rust-lang.org/cargo/reference/config.html#termcolor
