### PR TITLE
edit docs of `assert_debug_snapshot`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -378,6 +378,8 @@ macro_rules! _prepare_snapshot_for_redaction {
 /// simple values that do not implement the `Serialize` trait but does not
 /// permit redactions.
 ///
+/// Debug is called with `"{:#?}"`, which means this uses pretty-print.
+///
 /// The snapshot name is optional.
 #[macro_export]
 macro_rules! assert_debug_snapshot {


### PR DESCRIPTION
explaining that `Debug` is used in pretty-print mode