### PR TITLE
Fix minor typo in glob error message

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -126,7 +126,7 @@ pub fn glob_exec<F: FnMut(&Path)>(manifest_dir: &str, base: &Path, pattern: &str
             );
         }
         panic!(
-            "glob! resulted in {} snapshot assertion failure{}s",
+            "glob! resulted in {} snapshot assertion failure{}",
             top.failed,
             if top.failed == 1 { "" } else { "s" },
         );


### PR DESCRIPTION
Hi,
I noticed this small typo while using glob!.