### PR TITLE
Fix glob! input_file on Windows

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -315,7 +315,7 @@ impl<'a> SnapshotAssertionContext<'a> {
             .canonicalize()
             .ok()
             .and_then(|s| {
-                s.strip_prefix(self.cargo_workspace.as_path())
+                s.strip_prefix(self.cargo_workspace.canonicalize().unwrap())
                     .ok()
                     .map(|x| x.to_path_buf())
             })

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -315,9 +315,10 @@ impl<'a> SnapshotAssertionContext<'a> {
             .canonicalize()
             .ok()
             .and_then(|s| {
-                s.strip_prefix(self.cargo_workspace.canonicalize().unwrap())
+                self.cargo_workspace
+                    .canonicalize()
                     .ok()
-                    .map(|x| x.to_path_buf())
+                    .and_then(|cw| s.strip_prefix(cw).ok().map(|x| x.to_path_buf()))
             })
     }
 


### PR DESCRIPTION
Fix #336 
The issue is caused due to not canonicalize the stripped prefix when localizing the path.
For example in my environment i get `"D:\\Rust\\insta"` to strip from `"\\\\?\\D:\\Rust\\insta\\tests\\inputs\\goodbye.txt"` while when canonicalized becomes the correct prefix `"\\\\?\\D:\\Rust\\insta"`.
I used unwrap with the assumption that if canonicalize fails the previous call to canonicalize would also fail and it doesn't arrive at the unwrap.