### PR TITLE
Pass `--color=...` to libtest

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -909,7 +909,6 @@ fn prepare_test_runner<'snapshot_ref>(
         }
         _ => {}
     };
-    dbg!(&proc.get_args());
     Ok((proc, snapshot_ref_file, prevents_doc_run))
 }
 


### PR DESCRIPTION
Two parts to https://github.com/mitsuhiko/insta/issues/367 :
- The libtest output, which this PR solves
  - I've hand-tested it
  - Possibly this becomes moot if `cargo` is changed to handle more of the output
- The `insta` output when insta is called by libtest; e.g. the diffs. There's not much we can do from `cargo-insta`, but [`CLICOLOR_FORCE`](http://bixense.com/clicolors/) works, because `console` reads it
