### PR TITLE
cargo-insta: edit reject message

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -270,7 +270,7 @@ fn query_snapshot(
             println!(
                 "  {} reject     {}",
                 style("r").red().bold(),
-                style("keep the old snapshot").dim()
+                style("retain the old snapshot").dim()
             );
         } else {
             println!(

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -265,11 +265,21 @@ fn query_snapshot(
             style("a").green().bold(),
             style("keep the new snapshot").dim()
         );
-        println!(
-            "  {} reject     {}",
-            style("r").red().bold(),
-            style("keep the old snapshot").dim()
-        );
+
+        if old.is_some() {
+            println!(
+                "  {} reject     {}",
+                style("r").red().bold(),
+                style("keep the old snapshot").dim()
+            );
+        } else {
+            println!(
+                "  {} reject     {}",
+                style("r").red().bold(),
+                style("reject the new snapshot").dim()
+            );
+        }
+
         println!(
             "  {} skip       {}",
             style("s").yellow().bold(),


### PR DESCRIPTION
Now the message is aware of whether there is an old snapshot or not.