### PR TITLE
cargo-insta: reduce visibility of all items

### DIFF
--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -10,13 +10,13 @@ use serde::Deserialize;
 use crate::utils::err_msg;
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct Target {
+struct Target {
     src_path: PathBuf,
     kind: HashSet<String>,
 }
 
 #[derive(Deserialize, Clone, Debug)]
-pub struct Package {
+pub(crate) struct Package {
     name: String,
     version: String,
     id: String,
@@ -25,14 +25,14 @@ pub struct Package {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct Metadata {
+pub(crate) struct Metadata {
     packages: Vec<Package>,
     workspace_members: Vec<String>,
     workspace_root: String,
 }
 
 impl Metadata {
-    pub fn workspace_root(&self) -> &Path {
+    pub(crate) fn workspace_root(&self) -> &Path {
         Path::new(&self.workspace_root)
     }
 }
@@ -43,19 +43,19 @@ struct ProjectLocation {
 }
 
 impl Package {
-    pub fn manifest_path(&self) -> &Path {
+    pub(crate) fn manifest_path(&self) -> &Path {
         &self.manifest_path
     }
 
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         &self.name
     }
 
-    pub fn version(&self) -> &str {
+    pub(crate) fn version(&self) -> &str {
         &self.version
     }
 
-    pub fn find_snapshot_roots(&self) -> Vec<PathBuf> {
+    pub(crate) fn find_snapshot_roots(&self) -> Vec<PathBuf> {
         let mut roots = Vec::new();
 
         // the manifest path's parent is always a snapshot container.  For
@@ -98,13 +98,15 @@ impl Package {
     }
 }
 
-pub fn get_cargo() -> String {
+pub(crate) fn get_cargo() -> String {
     env::var("CARGO")
         .ok()
         .unwrap_or_else(|| "cargo".to_string())
 }
 
-pub fn get_package_metadata(manifest_path: Option<&Path>) -> Result<Metadata, Box<dyn Error>> {
+pub(crate) fn get_package_metadata(
+    manifest_path: Option<&Path>,
+) -> Result<Metadata, Box<dyn Error>> {
     let mut cmd = process::Command::new(get_cargo());
     cmd.arg("metadata")
         .arg("--no-deps")
@@ -157,7 +159,10 @@ fn find_all_packages(metadata: &Metadata) -> Vec<Package> {
         .collect()
 }
 
-pub fn find_packages(metadata: &Metadata, all: bool) -> Result<Vec<Package>, Box<dyn Error>> {
+pub(crate) fn find_packages(
+    metadata: &Metadata,
+    all: bool,
+) -> Result<Vec<Package>, Box<dyn Error>> {
     if all {
         Ok(find_all_packages(metadata))
     } else {

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -30,13 +30,13 @@ use crate::walk::{find_snapshots, make_deletion_walker, make_snapshot_walker, Fi
     global_setting = AppSettings::DeriveDisplayOrder,
     global_setting = AppSettings::DontCollapseArgsInUsage
 )]
-pub struct Opts {
+struct Opts {
     /// Coloring
     #[structopt(long, global = true, value_name = "WHEN", possible_values=&["auto", "always", "never"])]
-    pub color: Option<String>,
+    color: Option<String>,
 
     #[structopt(subcommand)]
-    pub command: Command,
+    command: Command,
 }
 
 #[derive(StructOpt, Debug)]
@@ -44,7 +44,7 @@ pub struct Opts {
     bin_name = "cargo insta",
     after_help = "For the online documentation of the latest version, see https://insta.rs/docs/cli/."
 )]
-pub enum Command {
+enum Command {
     /// Interactively review snapshots
     #[structopt(name = "review", alias = "verify")]
     Review(ProcessCommand),
@@ -67,158 +67,158 @@ pub enum Command {
 
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(rename_all = "kebab-case")]
-pub struct TargetArgs {
+struct TargetArgs {
     /// Path to Cargo.toml
     #[structopt(long, value_name = "PATH", parse(from_os_str))]
-    pub manifest_path: Option<PathBuf>,
+    manifest_path: Option<PathBuf>,
     /// Explicit path to the workspace root
     #[structopt(long, value_name = "PATH", parse(from_os_str))]
-    pub workspace_root: Option<PathBuf>,
+    workspace_root: Option<PathBuf>,
     /// Sets the extensions to consider.  Defaults to `.snap`
     #[structopt(short = "e", long, value_name = "EXTENSIONS", multiple = true)]
-    pub extensions: Vec<String>,
+    extensions: Vec<String>,
     /// Work on all packages in the workspace
     #[structopt(long)]
-    pub workspace: bool,
+    workspace: bool,
     /// Alias for --workspace (deprecated)
     #[structopt(long)]
-    pub all: bool,
+    all: bool,
     /// Also walk into ignored paths.
     #[structopt(long, alias = "no-ignore")]
-    pub include_ignored: bool,
+    include_ignored: bool,
     /// Also include hidden paths.
     #[structopt(long)]
-    pub include_hidden: bool,
+    include_hidden: bool,
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub struct ProcessCommand {
+struct ProcessCommand {
     #[structopt(flatten)]
-    pub target_args: TargetArgs,
+    target_args: TargetArgs,
     /// Limits the operation to one or more snapshots.
     #[structopt(long = "snapshot")]
-    pub snapshot_filter: Option<Vec<String>>,
+    snapshot_filter: Option<Vec<String>>,
     /// Do not print to stdout.
     #[structopt(short = "q", long)]
-    pub quiet: bool,
+    quiet: bool,
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub struct TestCommand {
+struct TestCommand {
     #[structopt(flatten)]
-    pub target_args: TargetArgs,
+    target_args: TargetArgs,
     /// Test only this package's library unit tests
     #[structopt(long)]
-    pub lib: bool,
+    lib: bool,
     /// Test only the specified binary
     #[structopt(long)]
-    pub bin: Option<String>,
+    bin: Option<String>,
     /// Test all binaries
     #[structopt(long)]
-    pub bins: bool,
+    bins: bool,
     /// Test only the specified example
     #[structopt(long)]
-    pub example: Option<String>,
+    example: Option<String>,
     /// Test all examples
     #[structopt(long)]
-    pub examples: bool,
+    examples: bool,
     /// Test only the specified test target
     #[structopt(long)]
-    pub test: Option<String>,
+    test: Option<String>,
     /// Test all tests
     #[structopt(long)]
-    pub tests: bool,
+    tests: bool,
     /// Package to run tests for
     #[structopt(short = "p", long)]
-    pub package: Option<String>,
+    package: Option<String>,
     /// Exclude packages from the test
     #[structopt(long, value_name = "SPEC")]
-    pub exclude: Option<String>,
+    exclude: Option<String>,
     /// Disable force-passing of snapshot tests
     #[structopt(long)]
-    pub no_force_pass: bool,
+    no_force_pass: bool,
     /// Prevent running all tests regardless of failure
     #[structopt(long)]
-    pub fail_fast: bool,
+    fail_fast: bool,
     /// Space-separated list of features to activate
     #[structopt(long, value_name = "FEATURES")]
-    pub features: Option<String>,
+    features: Option<String>,
     /// Number of parallel jobs, defaults to # of CPUs
     #[structopt(short = "j", long)]
-    pub jobs: Option<usize>,
+    jobs: Option<usize>,
     /// Build artifacts in release mode, with optimizations
     #[structopt(long)]
-    pub release: bool,
+    release: bool,
     /// Build artifacts with the specified profile
     #[structopt(long)]
-    pub profile: Option<String>,
+    profile: Option<String>,
     /// Activate all available features
     #[structopt(long)]
-    pub all_features: bool,
+    all_features: bool,
     /// Do not activate the `default` feature
     #[structopt(long)]
-    pub no_default_features: bool,
+    no_default_features: bool,
     /// Build for the target triple
     #[structopt(long)]
-    pub target: Option<String>,
+    target: Option<String>,
     /// Follow up with review.
     #[structopt(long)]
-    pub review: bool,
+    review: bool,
     /// Accept all snapshots after test.
     #[structopt(long, conflicts_with = "review")]
-    pub accept: bool,
+    accept: bool,
     /// Accept all new (previously unseen).
     #[structopt(long)]
-    pub accept_unseen: bool,
+    accept_unseen: bool,
     /// Instructs the test command to just assert.
     #[structopt(long)]
-    pub check: bool,
+    check: bool,
     /// Do not reject pending snapshots before run.
     #[structopt(long)]
-    pub keep_pending: bool,
+    keep_pending: bool,
     /// Update all snapshots even if they are still matching.
     #[structopt(long)]
-    pub force_update_snapshots: bool,
+    force_update_snapshots: bool,
     /// Controls what happens with unreferenced snapshots.
     #[structopt(long, default_value="ignore", possible_values=&["ignore", "warn", "reject", "delete", "auto"])]
-    pub unreferenced: String,
+    unreferenced: String,
     /// Delete unreferenced snapshots after the test run.
     #[structopt(long, hidden = true)]
-    pub delete_unreferenced_snapshots: bool,
+    delete_unreferenced_snapshots: bool,
     /// Filters to apply to the insta glob feature.
     #[structopt(long)]
-    pub glob_filter: Vec<String>,
+    glob_filter: Vec<String>,
     /// Do not pass the quiet flag (`-q`) to tests.
     #[structopt(short = "Q", long)]
-    pub no_quiet: bool,
+    no_quiet: bool,
     /// Picks the test runner.
     #[structopt(long, default_value="auto", possible_values=&["auto", "cargo-test", "nextest"])]
-    pub test_runner: String,
+    test_runner: String,
     /// Options passed to cargo test
     // Sets raw to true so that `--` is required
     #[structopt(name = "CARGO_TEST_ARGS", raw(true))]
-    pub cargo_options: Vec<String>,
+    cargo_options: Vec<String>,
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub struct PendingSnapshotsCommand {
+struct PendingSnapshotsCommand {
     #[structopt(flatten)]
-    pub target_args: TargetArgs,
+    target_args: TargetArgs,
     /// Changes the output from human readable to JSON.
     #[structopt(long)]
-    pub as_json: bool,
+    as_json: bool,
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt(rename_all = "kebab-case")]
-pub struct ShowCommand {
+struct ShowCommand {
     #[structopt(flatten)]
-    pub target_args: TargetArgs,
+    target_args: TargetArgs,
     /// The path to the snapshot file.
-    pub path: PathBuf,
+    path: PathBuf,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1050,7 +1050,7 @@ fn show_undiscovered_hint(
     );
 }
 
-pub fn run() -> Result<(), Box<dyn Error>> {
+pub(crate) fn run() -> Result<(), Box<dyn Error>> {
     // chop off cargo
     let mut args: Vec<_> = env::args_os().collect();
     if env::var("CARGO").is_ok() && args.get(1).and_then(|x| x.to_str()) == Some("insta") {

--- a/cargo-insta/src/container.rs
+++ b/cargo-insta/src/container.rs
@@ -8,29 +8,29 @@ use insta::_cargo_insta_support::PendingInlineSnapshot;
 use crate::inline::FilePatcher;
 
 #[derive(Clone, Copy, Debug)]
-pub enum Operation {
+pub(crate) enum Operation {
     Accept,
     Reject,
     Skip,
 }
 
 #[derive(Debug)]
-pub enum SnapshotContainerKind {
+pub(crate) enum SnapshotContainerKind {
     Inline,
     External,
 }
 
 #[derive(Debug)]
-pub struct PendingSnapshot {
-    pub id: usize,
-    pub old: Option<Snapshot>,
-    pub new: Snapshot,
-    pub op: Operation,
-    pub line: Option<u32>,
+pub(crate) struct PendingSnapshot {
+    id: usize,
+    pub(crate) old: Option<Snapshot>,
+    pub(crate) new: Snapshot,
+    pub(crate) op: Operation,
+    pub(crate) line: Option<u32>,
 }
 
 impl PendingSnapshot {
-    pub fn summary(&self) -> String {
+    pub(crate) fn summary(&self) -> String {
         use std::fmt::Write;
         let mut rv = String::new();
         if let Some(source) = self.new.metadata().source() {
@@ -47,7 +47,7 @@ impl PendingSnapshot {
 }
 
 #[derive(Debug)]
-pub struct SnapshotContainer {
+pub(crate) struct SnapshotContainer {
     snapshot_path: PathBuf,
     target_path: PathBuf,
     kind: SnapshotContainerKind,
@@ -56,7 +56,7 @@ pub struct SnapshotContainer {
 }
 
 impl SnapshotContainer {
-    pub fn load(
+    pub(crate) fn load(
         snapshot_path: PathBuf,
         target_path: PathBuf,
         kind: SnapshotContainerKind,
@@ -128,26 +128,26 @@ impl SnapshotContainer {
         })
     }
 
-    pub fn target_file(&self) -> &Path {
+    pub(crate) fn target_file(&self) -> &Path {
         &self.target_path
     }
 
-    pub fn snapshot_file(&self) -> Option<&Path> {
+    pub(crate) fn snapshot_file(&self) -> Option<&Path> {
         match self.kind {
             SnapshotContainerKind::External => Some(&self.target_path),
             SnapshotContainerKind::Inline => None,
         }
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.snapshots.len()
     }
 
-    pub fn iter_snapshots(&mut self) -> impl Iterator<Item = &'_ mut PendingSnapshot> {
+    pub(crate) fn iter_snapshots(&mut self) -> impl Iterator<Item = &'_ mut PendingSnapshot> {
         self.snapshots.iter_mut()
     }
 
-    pub fn commit(&mut self) -> Result<(), Box<dyn Error>> {
+    pub(crate) fn commit(&mut self) -> Result<(), Box<dyn Error>> {
         if let Some(ref mut patcher) = self.patcher {
             let mut new_pending = vec![];
             let mut did_accept = false;

--- a/cargo-insta/src/container.rs
+++ b/cargo-insta/src/container.rs
@@ -22,6 +22,7 @@ pub(crate) enum SnapshotContainerKind {
 
 #[derive(Debug)]
 pub(crate) struct PendingSnapshot {
+    #[allow(dead_code)]
     id: usize,
     pub(crate) old: Option<Snapshot>,
     pub(crate) new: Snapshot,

--- a/cargo-insta/src/utils.rs
+++ b/cargo-insta/src/utils.rs
@@ -3,7 +3,7 @@ use std::fmt;
 
 /// Close without message but exit code.
 #[derive(Debug)]
-pub struct QuietExit(pub i32);
+pub(crate) struct QuietExit(pub(crate) i32);
 
 impl Error for QuietExit {}
 
@@ -14,7 +14,7 @@ impl fmt::Display for QuietExit {
 }
 
 #[derive(Debug)]
-pub struct ErrMsg(String);
+struct ErrMsg(String);
 
 impl Error for ErrMsg {}
 
@@ -24,6 +24,6 @@ impl fmt::Display for ErrMsg {
     }
 }
 
-pub fn err_msg<S: Into<String>>(s: S) -> Box<dyn Error> {
+pub(crate) fn err_msg<S: Into<String>>(s: S) -> Box<dyn Error> {
     Box::new(ErrMsg(s.into()))
 }

--- a/cargo-insta/src/walk.rs
+++ b/cargo-insta/src/walk.rs
@@ -10,9 +10,9 @@ use crate::cargo::Package;
 use crate::container::{SnapshotContainer, SnapshotContainerKind};
 
 #[derive(Debug, Copy, Clone)]
-pub struct FindFlags {
-    pub include_ignored: bool,
-    pub include_hidden: bool,
+pub(crate) struct FindFlags {
+    pub(crate) include_ignored: bool,
+    pub(crate) include_hidden: bool,
 }
 
 fn is_hidden(entry: &DirEntry) -> bool {
@@ -24,7 +24,7 @@ fn is_hidden(entry: &DirEntry) -> bool {
 }
 
 /// Finds all snapshots
-pub fn find_snapshots<'a>(
+pub(crate) fn find_snapshots<'a>(
     root: &Path,
     extensions: &'a [&'a str],
     flags: FindFlags,
@@ -57,7 +57,7 @@ pub fn find_snapshots<'a>(
 }
 
 /// Creates a walker for snapshots.
-pub fn make_snapshot_walker(path: &Path, extensions: &[&str], flags: FindFlags) -> Walk {
+pub(crate) fn make_snapshot_walker(path: &Path, extensions: &[&str], flags: FindFlags) -> Walk {
     let mut builder = WalkBuilder::new(path);
     builder.standard_filters(!flags.include_ignored);
     if flags.include_hidden {
@@ -84,7 +84,7 @@ pub fn make_snapshot_walker(path: &Path, extensions: &[&str], flags: FindFlags) 
 /// A walker that is used by the snapshot deletion code.
 ///
 /// This really should be using the same logic as the main snapshot walker but today is is not.
-pub fn make_deletion_walker(
+pub(crate) fn make_deletion_walker(
     workspace_root: &Path,
     known_packages: Option<&[Package]>,
     selected_package: Option<&str>,


### PR DESCRIPTION
Items which are marked pub are not considered by rustc's dead code
lints, allowing obvious bugs like the one fixed in 84cddf9c7045a2769c6b06dd0259640c0ba2df5c.

This exposed the fact that `PendingSnapshot.id` is unused, so `#[allow(dead_code)]` is added to that field.