### PR TITLE
cargo-insta: fix --manifest-path <virtual-workspace>

### DIFF
--- a/cargo-insta/Cargo.lock
+++ b/cargo-insta/Cargo.lock
@@ -36,9 +36,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-insta"
 version = "1.33.0"
 dependencies = [
+ "cargo_metadata",
  "console",
  "ignore",
  "insta",
@@ -49,6 +59,29 @@ dependencies = [
  "syn",
  "tempfile",
  "uuid",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9ac64500cc83ce4b9f8dafa78186aa008c8dea77a09b94cd307fd0cd5022a8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -459,6 +492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad977052201c6de01a8ef2aa3378c4bd23217a056337d1d6da40468d267a4fb0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 insta = { version = "=1.33.0", path = "..", features = ["json", "yaml", "redactions", "_cargo_insta_internal"] }
+cargo_metadata = { version = "0.18.0", default-features = false }
 console = "0.15.4"
 structopt = { version = "0.3.26", default-features = false }
 serde = { version = "1.0.117", features = ["derive"] }

--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -1,190 +1,76 @@
-use std::collections::HashSet;
-use std::env;
 use std::error::Error;
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::process;
 
-use serde::Deserialize;
+pub(crate) use cargo_metadata::{Metadata, MetadataCommand, Package};
 
-use crate::utils::err_msg;
+pub(crate) fn find_snapshot_roots(package: &Package) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
 
-#[derive(Deserialize, Clone, Debug)]
-struct Target {
-    src_path: PathBuf,
-    kind: HashSet<String>,
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub(crate) struct Package {
-    name: String,
-    version: String,
-    id: String,
-    manifest_path: PathBuf,
-    targets: Vec<Target>,
-}
-
-#[derive(Deserialize, Debug)]
-pub(crate) struct Metadata {
-    packages: Vec<Package>,
-    workspace_members: Vec<String>,
-    workspace_root: String,
-}
-
-impl Metadata {
-    pub(crate) fn workspace_root(&self) -> &Path {
-        Path::new(&self.workspace_root)
-    }
-}
-
-#[derive(Deserialize, Debug)]
-struct ProjectLocation {
-    root: PathBuf,
-}
-
-impl Package {
-    pub(crate) fn manifest_path(&self) -> &Path {
-        &self.manifest_path
+    // the manifest path's parent is always a snapshot container.  For
+    // a rationale see GH-70.  But generally a user would expect to be
+    // able to put a snapshot into foo/snapshots instead of foo/src/snapshots.
+    if let Some(manifest) = package.manifest_path.parent() {
+        roots.push(manifest.as_std_path().to_path_buf());
     }
 
-    pub(crate) fn name(&self) -> &str {
-        &self.name
-    }
-
-    pub(crate) fn version(&self) -> &str {
-        &self.version
-    }
-
-    pub(crate) fn find_snapshot_roots(&self) -> Vec<PathBuf> {
-        let mut roots = Vec::new();
-
-        // the manifest path's parent is always a snapshot container.  For
-        // a rationale see GH-70.  But generally a user would expect to be
-        // able to put a snapshot into foo/snapshots instead of foo/src/snapshots.
-        if let Some(manifest) = self.manifest_path.parent() {
-            roots.push(manifest.to_path_buf());
+    // additionally check all targets.
+    for target in &package.targets {
+        // custom build scripts we can safely skip over.  In the past this
+        // caused issues with duplicate paths but that's resolved in other
+        // ways now.  We do not want to pick up snapshots in such places
+        // though.
+        if target.kind.iter().any(|kind| kind == "custom-build") {
+            continue;
         }
 
-        // additionally check all targets.
-        for target in &self.targets {
-            // custom build scripts we can safely skip over.  In the past this
-            // caused issues with duplicate paths but that's resolved in other
-            // ways now.  We do not want to pick up snapshots in such places
-            // though.
-            if target.kind.contains("custom-build") {
-                continue;
-            }
-
-            // this gives us the containing source folder.  Typically this is
-            // something like crate/src.
-            let root = target.src_path.parent().unwrap();
-            roots.push(root.to_path_buf());
-        }
-
-        // reduce roots to avoid traversing into paths twice.  If we have both
-        // /foo and /foo/bar as roots we would only walk into /foo.  Otherwise
-        // we would encounter paths twice.  If we don't skip them here we run
-        // into issues where the existence of a build script causes a snapshot
-        // to be picked up twice since the same path is determined.  (GH-15)
-        roots.sort_by_key(|x| x.as_os_str().len());
-        let mut reduced_roots = vec![];
-        for root in roots {
-            if !reduced_roots.iter().any(|x| root.starts_with(x)) {
-                reduced_roots.push(root);
-            }
-        }
-
-        reduced_roots
+        // this gives us the containing source folder.  Typically this is
+        // something like crate/src.
+        let root = target.src_path.parent().unwrap().as_std_path();
+        roots.push(root.to_path_buf());
     }
+
+    // reduce roots to avoid traversing into paths twice.  If we have both
+    // /foo and /foo/bar as roots we would only walk into /foo.  Otherwise
+    // we would encounter paths twice.  If we don't skip them here we run
+    // into issues where the existence of a build script causes a snapshot
+    // to be picked up twice since the same path is determined.  (GH-15)
+    roots.sort_by_key(|x| x.as_os_str().len());
+    let mut reduced_roots = vec![];
+    for root in roots {
+        if !reduced_roots.iter().any(|x| root.starts_with(x)) {
+            reduced_roots.push(root);
+        }
+    }
+
+    reduced_roots
 }
 
-pub(crate) fn get_cargo() -> String {
-    env::var("CARGO")
-        .ok()
-        .unwrap_or_else(|| "cargo".to_string())
-}
-
-pub(crate) fn get_package_metadata(
+pub(crate) fn get_metadata(
     manifest_path: Option<&Path>,
-) -> Result<Metadata, Box<dyn Error>> {
-    let mut cmd = process::Command::new(get_cargo());
-    cmd.arg("metadata")
-        .arg("--no-deps")
-        .arg("--format-version=1");
-    if let Some(manifest_path) = manifest_path {
-        if !fs::metadata(manifest_path)
-            .ok()
-            .map_or(false, |x| x.is_file())
-        {
-            return Err(err_msg(
-                "the manifest-path must be a path to a Cargo.toml file",
-            ));
-        }
-        cmd.arg("--manifest-path").arg(manifest_path.as_os_str());
-    }
-    let output = cmd.output()?;
-    if !output.status.success() {
-        let msg = String::from_utf8_lossy(&output.stderr);
-        return Err(err_msg(format!(
-            "cargo erroried getting metadata: {}",
-            msg.trim()
-        )));
-    }
-    Ok(serde_json::from_slice(&output.stdout)?)
-}
-
-fn get_default_manifest() -> Result<Option<PathBuf>, Box<dyn Error>> {
-    let output = process::Command::new(get_cargo())
-        .arg("locate-project")
-        .output()?;
-    if output.status.success() {
-        let loc: ProjectLocation = serde_json::from_slice(&output.stdout)?;
-        Ok(Some(loc.root))
-    } else {
-        Ok(None)
-    }
-}
-
-fn find_all_packages(metadata: &Metadata) -> Vec<Package> {
-    metadata
-        .packages
-        .iter()
-        .filter_map(|package| {
-            if metadata.workspace_members.contains(&package.id) {
-                Some(package.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-pub(crate) fn find_packages(
-    metadata: &Metadata,
     all: bool,
-) -> Result<Vec<Package>, Box<dyn Error>> {
+) -> Result<Metadata, Box<dyn Error>> {
+    let mut cmd = MetadataCommand::new();
+    if let Some(manifest_path) = manifest_path {
+        cmd.manifest_path(manifest_path);
+    }
     if all {
-        Ok(find_all_packages(metadata))
-    } else {
-        let default_manifest = get_default_manifest()?
-            .ok_or_else(|| {
-                err_msg(
-                    "Could not find `Cargo.toml` in the current folder or any parent directory.",
-                )
-            })?
-            .canonicalize()?;
-        let mut rv = vec![];
-        for package in &metadata.packages {
-            if package.manifest_path.canonicalize()? == default_manifest {
-                rv.push(package.clone());
-            }
-        }
-        if rv.is_empty() {
-            // if we don't find anything we're in a workspace root that has no
-            // root member in which case --all is implied.
-            Ok(find_all_packages(metadata))
-        } else {
-            Ok(rv)
+        cmd.no_deps();
+    }
+    let mut metadata = cmd.exec()?;
+    let Metadata {
+        packages,
+        workspace_members,
+        resolve,
+        ..
+    } = &mut metadata;
+    match resolve
+        .as_ref()
+        .and_then(|cargo_metadata::Resolve { root, .. }| root.as_ref())
+    {
+        Some(root) => packages.retain(|Package { id, .. }| id == root),
+        None => {
+            packages.retain(|Package { id, .. }| workspace_members.contains(id));
         }
     }
+    Ok(metadata)
 }

--- a/cargo-insta/src/walk.rs
+++ b/cargo-insta/src/walk.rs
@@ -95,11 +95,11 @@ pub(crate) fn make_deletion_walker(
             .filter_map(|x| {
                 // filter out packages we did not ask for.
                 if let Some(only_package) = selected_package {
-                    if x.name() != only_package {
+                    if x.name != only_package {
                         return None;
                     }
                 }
-                x.manifest_path().parent().unwrap().canonicalize().ok()
+                x.manifest_path.parent().unwrap().canonicalize().ok()
             })
             .collect()
     } else {


### PR DESCRIPTION
Prior to this change --manifest-path only worked properly if it pointed to the root of a non-virtual workspace.

Rewrite all the cargo interaction to use cargo-metadata which crucially provides `Metadata::resolve::root` which is used to determine which package --manifest-path was pointing to.

https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace