### PR TITLE
build(deps): Depend on ron 0.7 or 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ dep_csv = { package = "csv", version = "=1.1.6", optional = true }
 console = { version = "0.15.4", optional = true, default-features = false }
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
-dep_ron = { package = "ron", version = "0.7.1", optional = true }
+dep_ron = { package = "ron", version = ">=0.7, <0.9", optional = true }
 dep_toml = { package = "toml", version = "0.5.7", optional = true }
 globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }


### PR DESCRIPTION
Depend on `ron` version 0.7 or 0.8 using `version = ">=0.7, <0.9"`.
