### PR TITLE
Added alternative redactions syntax for rustfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.35.0
 
+- Added new alternative `match .. { ... }` syntax to redactions for better
+  `rustfmt` support.  (#428)
 - The `--package` parameter can be supplied multiple times now.  (#427)
 
 ## 1.34.0

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,8 +30,9 @@ macro_rules! _function_name {
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions see [redactions](https://docs.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
 #[cfg(feature = "csv")]
@@ -41,16 +42,16 @@ macro_rules! assert_csv_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, Csv, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Csv, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Csv);
     }};
     ($name:expr, $value:expr) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, Csv);
     }};
-    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Csv);
     }};
     ($value:expr) => {{
@@ -74,8 +75,9 @@ macro_rules! assert_csv_snapshot {
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
 #[cfg(feature = "toml")]
@@ -85,16 +87,16 @@ macro_rules! assert_toml_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, Toml, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Toml, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Toml);
     }};
     ($name:expr, $value:expr) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, Toml);
     }};
-    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Toml);
     }};
     ($value:expr) => {{
@@ -124,8 +126,9 @@ macro_rules! assert_toml_snapshot {
 /// macro, this one has a secondary mode where redactions can be defined.
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// Example:
 ///
@@ -153,16 +156,16 @@ macro_rules! assert_yaml_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, Yaml, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Yaml, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Yaml);
     }};
     ($name:expr, $value:expr) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, Yaml);
     }};
-    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Yaml);
     }};
     ($value:expr) => {{
@@ -186,8 +189,9 @@ macro_rules! assert_yaml_snapshot {
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
 #[cfg(feature = "ron")]
@@ -197,16 +201,16 @@ macro_rules! assert_ron_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, Ron, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Ron, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Ron);
     }};
     ($name:expr, $value:expr) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, Ron);
     }};
-    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Ron);
     }};
     ($value:expr) => {{
@@ -230,8 +234,9 @@ macro_rules! assert_ron_snapshot {
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
 #[cfg(feature = "json")]
@@ -241,16 +246,16 @@ macro_rules! assert_json_snapshot {
     ($value:expr, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, Json, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
         $crate::_assert_serialized_snapshot!($value, {$($k => $v),*}, Json, @$snapshot);
     }};
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!($crate::_macro_support::AutoName, $value, {$($k => $v),*}, Json);
     }};
     ($name:expr, $value:expr) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, Json);
     }};
-    ($name:expr, $value:expr, {$($k:expr => $v:expr),*$(,)?}) => {{
+    ($name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
         $crate::_assert_serialized_snapshot!(Some($name), $value, {$($k => $v),*}, Json);
     }};
     ($value:expr) => {{
@@ -275,8 +280,9 @@ macro_rules! assert_json_snapshot {
 /// ```
 ///
 /// The third argument to the macro can be an object expression for redaction.
-/// It's in the form `{ selector => replacement }`.  For more information
-/// about redactions refer to the [redactions feature in the guide](https://insta.rs/docs/redactions/).
+/// It's in the form `{ selector => replacement }` or `match .. { selector => replacement }`.
+/// For more information about redactions refer to the [redactions feature in
+/// the guide](https://insta.rs/docs/redactions/).
 ///
 /// The snapshot name is optional but can be provided as first argument.
 #[cfg(feature = "json")]

--- a/tests/snapshots/test_redaction__with_random_value_and_trailing_comma_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_and_trailing_comma_match.snap
@@ -1,0 +1,9 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 11,\n        username: \"john_doe\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+id: "[id]"
+username: john_doe
+email: john@example.com
+extra: ""
+

--- a/tests/snapshots/test_redaction__with_random_value_csv_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_csv_match.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 44,\n        username: \"julius_csv\".to_string(),\n        email: Email(\"julius@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+id,username,email,extra
+[id],julius_csv,julius@example.com,

--- a/tests/snapshots/test_redaction__with_random_value_json_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_json_match.snap
@@ -1,0 +1,10 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 9999,\n        username: \"jason_doe\".to_string(),\n        email: Email(\"jason@example.com\".to_string()),\n        extra: \"ssn goes here\".to_string(),\n    }"
+---
+{
+  "id": "[id]",
+  "username": "jason_doe",
+  "email": "jason@example.com",
+  "extra": "[extra]"
+}

--- a/tests/snapshots/test_redaction__with_random_value_ron_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_ron_match.snap
@@ -1,0 +1,10 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 53,\n        username: \"john_ron\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+User(
+  id: "[id]",
+  username: "john_ron",
+  email: Email("john@example.com"),
+  extra: "",
+)

--- a/tests/snapshots/test_redaction__with_random_value_toml_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_toml_match.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 53,\n        username: \"john_ron\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+id = '[id]'
+username = 'john_ron'
+email = 'john@example.com'
+extra = ''

--- a/tests/test_redaction.rs
+++ b/tests/test_redaction.rs
@@ -86,6 +86,22 @@ fn test_with_random_value_and_trailing_comma() {
     });
 }
 
+#[cfg(feature = "yaml")]
+#[test]
+fn test_with_random_value_and_trailing_comma_match() {
+    assert_yaml_snapshot!(
+        &User {
+            id: 11,
+            username: "john_doe".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        }
+    );
+}
+
 #[cfg(feature = "csv")]
 #[test]
 fn test_with_random_value_csv() {
@@ -97,6 +113,22 @@ fn test_with_random_value_csv() {
     }, {
         ".id" => "[id]"
     });
+}
+
+#[cfg(feature = "csv")]
+#[test]
+fn test_with_random_value_csv_match() {
+    assert_csv_snapshot!(
+        &User {
+            id: 44,
+            username: "julius_csv".to_string(),
+            email: Email("julius@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        }
+    );
 }
 
 #[cfg(feature = "ron")]
@@ -112,6 +144,22 @@ fn test_with_random_value_ron() {
     });
 }
 
+#[cfg(feature = "ron")]
+#[test]
+fn test_with_random_value_ron_match() {
+    assert_ron_snapshot!(
+        &User {
+            id: 53,
+            username: "john_ron".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        }
+    );
+}
+
 #[cfg(feature = "toml")]
 #[test]
 fn test_with_random_value_toml() {
@@ -123,6 +171,22 @@ fn test_with_random_value_toml() {
     }, {
         ".id" => "[id]"
     });
+}
+
+#[cfg(feature = "toml")]
+#[test]
+fn test_with_random_value_toml_match() {
+    assert_toml_snapshot!(
+        &User {
+            id: 53,
+            username: "john_ron".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        }
+    );
 }
 
 #[cfg(feature = "json")]
@@ -137,6 +201,23 @@ fn test_with_random_value_json() {
         ".id" => "[id]",
         ".extra" => "[extra]"
     });
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn test_with_random_value_json_match() {
+    assert_json_snapshot!(
+        &User {
+            id: 9999,
+            username: "jason_doe".to_string(),
+            email: Email("jason@example.com".to_string()),
+            extra: "ssn goes here".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+            ".extra" => "[extra]",
+        }
+    );
 }
 
 #[cfg(feature = "json")]


### PR DESCRIPTION
This adds a new optional redactions syntax for rustfmt support:

```rust
#[cfg(feature = "yaml")]
#[test]
fn test_with_random_value_and_trailing_comma_match() {
    assert_yaml_snapshot!(
        &User {
            id: 11,
            username: "john_doe".to_string(),
            email: Email("john@example.com".to_string()),
            extra: "".to_string(),
        },
        match .. {
            ".id" => "[id]",
        }
    );
}
```

Fixes #419