### PR TITLE
Fix error with a .config file (#340)

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -132,6 +132,9 @@ impl ToolConfig {
         let mut cfg = None;
         for choice in &[".config/insta.yaml", "insta.yaml", ".insta.yaml"] {
             let path = workspace_dir.join(choice);
+            if !path.exists() {
+                continue;
+            }
             match fs::read_to_string(path) {
                 Ok(s) => {
                     cfg = Some(yaml::parse_str(&s).map_err(Error::Deserialize)?);


### PR DESCRIPTION
Unfortunately, I was not able adding `NotADirectory` kind in the pattern machine because it's behind an experimental flag:

See <https://doc.rust-lang.org/std/io/enum.ErrorKind.html#variant.NotADirectory>/

Fix the #430 issue