### PR TITLE
Ignore leading newlines on snapshot comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to insta and cargo-insta are documented here.
 - Added new alternative `match .. { ... }` syntax to redactions for better
   `rustfmt` support.  (#428)
 - The `--package` parameter can be supplied multiple times now.  (#427)
+- Leading newlines in snapshots are now ignored to resolve issues with
+  inline snapshots that were never able to match.  (#444)
 
 ## 1.34.0
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -576,7 +576,13 @@ impl From<SnapshotContents> for String {
 
 impl PartialEq for SnapshotContents {
     fn eq(&self, other: &Self) -> bool {
-        self.0.trim_end() == other.0.trim_end()
+        self.0
+            .trim_start_matches(|x| x == '\r' || x == '\n')
+            .trim_end()
+            == other
+                .0
+                .trim_start_matches(|x| x == '\r' || x == '\n')
+                .trim_end()
     }
 }
 

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -286,3 +286,15 @@ fn test_inline_test_in_loop() {
         assert_snapshot!(i.to_string(), @"0");
     }
 }
+
+#[test]
+fn test_inline_snapshot_whitespace() {
+    assert_snapshot!("\n\nfoo\n\n    bar\n\n", @r###"
+
+
+    foo
+
+        bar
+
+    "###);
+}


### PR DESCRIPTION
Previously leading whitespace caused snapshots to mismatch. This is an issue for inline snapshots where the code that removes leading indentation cannot express this properly. For now solve this by ignoring leading newlines in addition to trailing spaces which are already ignored.

Ideally future versions of the macros would inject a special character into a snapshot if leading and trailing newlines play a role.