### PR TITLE
Toml@0.5.7 will sometimes fail to serialize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ console = { version = "0.15.4", optional = true, default-features = false }
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 dep_ron = { package = "ron", version = "0.7.1", optional = true }
-dep_toml = { package = "toml", version = "0.5.7", optional = true }
+dep_toml = { package = "toml", version = "0.8.1", optional = true }
 globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }

--- a/tests/snapshots/test_basic__toml.snap
+++ b/tests/snapshots/test_basic__toml.snap
@@ -1,0 +1,10 @@
+---
+source: tests/test_basic.rs
+expression: obj
+---
+name = "Frosty"
+registered = true
+
+[boat]
+length = 21
+has_motor = true

--- a/tests/snapshots/test_redaction__user_toml.snap
+++ b/tests/snapshots/test_redaction__user_toml.snap
@@ -2,7 +2,7 @@
 source: tests/test_redaction.rs
 expression: "&User {\n        id: 53,\n        username: \"john_ron\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
 ---
-id = '[id]'
-username = 'john_ron'
-email = 'john@example.com'
-extra = ''
+id = "[id]"
+username = "john_ron"
+email = "john@example.com"
+extra = ""

--- a/tests/snapshots/test_redaction__with_random_value_toml_match.snap
+++ b/tests/snapshots/test_redaction__with_random_value_toml_match.snap
@@ -2,7 +2,7 @@
 source: tests/test_redaction.rs
 expression: "&User {\n        id: 53,\n        username: \"john_ron\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
 ---
-id = '[id]'
-username = 'john_ron'
-email = 'john@example.com'
-extra = ''
+id = "[id]"
+username = "john_ron"
+email = "john@example.com"
+extra = ""

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -104,3 +104,37 @@ fn insta_sort_order() {
         insta::assert_yaml_snapshot!(m);
     });
 }
+
+#[cfg(feature = "toml")]
+#[cfg(feature = "serde")]
+#[test]
+fn test_toml() {
+    #[derive(serde::Serialize)]
+    pub struct MyObjectTest {
+        pub obj: MyObject,
+    }
+
+    #[derive(serde::Serialize)]
+    pub struct Boat {
+        pub length: i32,
+        pub has_motor: bool,
+    }
+
+    #[derive(serde::Serialize)]
+    pub struct MyObject {
+        pub name: String,
+        pub boat: Option<Boat>,
+        pub registered: bool,
+    }
+
+    let obj = MyObject {
+        name: "Frosty".to_string(),
+        boat: Some(Boat {
+            length: 21,
+            has_motor: true,
+        }),
+        registered: true,
+    };
+
+    insta::assert_toml_snapshot!(obj);
+}

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -158,8 +158,8 @@ fn test_toml_inline() {
         email: Email("peter@doe.invalid".into()),
     }, @r###"
     id = 42
-    username = 'peter-doe'
-    email = 'peter@doe.invalid'
+    username = "peter-doe"
+    email = "peter@doe.invalid"
     "###);
 }
 


### PR DESCRIPTION
Toml@0.5.7 will sometimes fail and produce the following error with a structure that can
be converted into valid toml:

```
Result::unwrap() on an Err value: ValueAfterTable
```

The crate can correctly serialize such objects in version 0.8.1.

Example:

```rust
 #[derive(serde::Serialize)]
  pub struct MyObjectTest {
      pub obj: MyObject,
  }

  #[derive(serde::Serialize)]
  pub struct Boat {
      pub length: i32,
      pub has_motor: bool,
  }

  #[derive(serde::Serialize)]
  pub struct MyObject {
      pub name: String,
      pub boat: Option<Boat>,
      pub registered: bool,
  }

  let obj = MyObject {
      name: "Frosty".to_string(),
      boat: Some(Boat {
          length: 21,
          has_motor: true,
      }),
      registered: true,
  };
```

Serializing this struct with toml@0.5.7 will result in:
```
`Result::unwrap()` on an `Err` value: ValueAfterTable
```

After updating toml to 0.8.1, the same structure will serialize to:
```toml
name = "Frosty"
registered = true

[boat]
length = 21
has_motor = true
```