### PR TITLE
Align env var with docs

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -186,6 +186,9 @@ struct TestCommand {
     /// Update all snapshots even if they are still matching.
     #[structopt(long)]
     force_update_snapshots: bool,
+    /// Require metadata as well as snapshots' contents to match.
+    #[structopt(long)]
+    require_full_match: bool,
     /// Handle unreferenced snapshots after a successful test run.
     #[structopt(long, default_value="ignore", possible_values=&["ignore", "warn", "reject", "delete", "auto"])]
     unreferenced: String,
@@ -883,7 +886,10 @@ fn prepare_test_runner<'snapshot_ref>(
         },
     );
     if cmd.force_update_snapshots {
-        proc.env("INSTA_FORCE_UPDATE_SNAPSHOTS", "1");
+        proc.env("INSTA_FORCE_UPDATE", "1");
+    }
+    if cmd.require_full_match {
+        proc.env("INSTA_REQUIRE_FULL_MATCH", "1");
     }
     let glob_filter =
         cmd.glob_filter

--- a/src/env.rs
+++ b/src/env.rs
@@ -143,14 +143,19 @@ impl ToolConfig {
         }
         let cfg = cfg.unwrap_or_else(|| Content::Map(Default::default()));
 
+        if let Ok("1") = env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").as_deref() {
+            eprintln!("INSTA_FORCE_UPDATE_SNAPSHOTS is deprecated, use INSTA_FORCE_UPDATE");
+            env::set_var("INSTA_FORCE_UPDATE", "1");
+        }
+
         Ok(ToolConfig {
-            force_update_snapshots: match env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").as_deref() {
+            force_update_snapshots: match env::var("INSTA_FORCE_UPDATE").as_deref() {
                 Err(_) | Ok("") => resolve(&cfg, &["behavior", "force_update"])
                     .and_then(|x| x.as_bool())
                     .unwrap_or(false),
                 Ok("0") => false,
                 Ok("1") => true,
-                _ => return Err(Error::Env("INSTA_FORCE_UPDATE_SNAPSHOTS")),
+                _ => return Err(Error::Env("INSTA_FORCE_UPDATE")),
             },
             force_pass: match env::var("INSTA_FORCE_PASS").as_deref() {
                 Err(_) | Ok("") => resolve(&cfg, &["behavior", "force_pass"])


### PR DESCRIPTION
The docs had `INSTA_FORCE_UPDATE`, but actually `INSTA_FORCE_UPDATE_SNAPSHOTS` was used. I kept the former, since that's consistent with the config file & cli options

Docs are here: https://github.com/mitsuhiko/insta/blob/7c00b0b037105481fd6548a1b66a1b9e4ed2efcb/src/lib.rs#L197