### PR TITLE
Better missing file errors

### DIFF
--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -24,19 +24,24 @@ pub enum Error {
     UnexpectedDataType,
     #[cfg(feature = "_cargo_insta_internal")]
     MissingField,
+    #[cfg(feature = "_cargo_insta_internal")]
+    FileIo(std::io::Error, std::path::PathBuf),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use Error::*;
         match self {
-            Self::FailedParsingYaml(p) => {
+            FailedParsingYaml(p) => {
                 f.write_str(format!("Failed parsing the YAML from {:?}", p.display()).as_str())
             }
-            Self::UnexpectedDataType => {
-                f.write_str("The present data type wasn't what was expected")
-            }
+            UnexpectedDataType => f.write_str("The present data type wasn't what was expected"),
             #[cfg(feature = "_cargo_insta_internal")]
-            Self::MissingField => f.write_str("A required field was missing"),
+            MissingField => f.write_str("A required field was missing"),
+            #[cfg(feature = "_cargo_insta_internal")]
+            FileIo(e, p) => {
+                f.write_str(format!("File error for {:?}: {}", p.display(), e).as_str())
+            }
         }
     }
 }

--- a/src/content/mod.rs
+++ b/src/content/mod.rs
@@ -30,16 +30,17 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use Error::*;
         match self {
-            FailedParsingYaml(p) => {
+            Error::FailedParsingYaml(p) => {
                 f.write_str(format!("Failed parsing the YAML from {:?}", p.display()).as_str())
             }
-            UnexpectedDataType => f.write_str("The present data type wasn't what was expected"),
+            Error::UnexpectedDataType => {
+                f.write_str("The present data type wasn't what was expected")
+            }
             #[cfg(feature = "_cargo_insta_internal")]
-            MissingField => f.write_str("A required field was missing"),
+            Error::MissingField => f.write_str("A required field was missing"),
             #[cfg(feature = "_cargo_insta_internal")]
-            FileIo(e, p) => {
+            Error::FileIo(e, p) => {
                 f.write_str(format!("File error for {:?}: {}", p.display(), e).as_str())
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,6 +293,7 @@ pub mod internals {
 #[cfg(feature = "_cargo_insta_internal")]
 pub mod _cargo_insta_support {
     pub use crate::{
+        content::Error as ContentError,
         env::{
             Error as ToolConfigError, OutputBehavior, SnapshotUpdate, TestRunner, ToolConfig,
             UnreferencedSnapshots,

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -40,7 +40,7 @@ impl PendingInlineSnapshot {
     #[cfg(feature = "_cargo_insta_internal")]
     pub fn load_batch(p: &Path) -> Result<Vec<PendingInlineSnapshot>, Box<dyn Error>> {
         let contents =
-            fs::read_to_string(p).map_err(|e| crate::content::Error::FileIo(e, p.to_path_buf()))?;
+            fs::read_to_string(p).map_err(|e| content::Error::FileIo(e, p.to_path_buf()))?;
 
         let mut rv: Vec<Self> = contents
             .lines()

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -39,7 +39,8 @@ impl PendingInlineSnapshot {
 
     #[cfg(feature = "_cargo_insta_internal")]
     pub fn load_batch(p: &Path) -> Result<Vec<PendingInlineSnapshot>, Box<dyn Error>> {
-        let contents = fs::read_to_string(p)?;
+        let contents =
+            fs::read_to_string(p).map_err(|e| crate::content::Error::FileIo(e, p.to_path_buf()))?;
 
         let mut rv: Vec<Self> = contents
             .lines()


### PR DESCRIPTION
I tracked down https://github.com/mitsuhiko/insta/issues/380 at last.

This doesn't solve the problem, but does show which file is being deleted, so it's not such a mystery. A future PR could change how these are handled so it's more permissive.

For example:

```
error: File error for `/Users/maximilian/workspace/prql/prqlc/prqlc-parser/src/.lexer.rs.pending-snap': No such file or directory (os error 2)
```