### PR TITLE
Restore cargo-insta compat with older insta

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -144,9 +144,15 @@ impl ToolConfig {
         }
         let cfg = cfg.unwrap_or_else(|| Content::Map(Default::default()));
 
-        if let Ok("1") = env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").as_deref() {
-            eprintln!("INSTA_FORCE_UPDATE_SNAPSHOTS is deprecated, use INSTA_FORCE_UPDATE");
-            env::set_var("INSTA_FORCE_UPDATE", "1");
+        // support for the deprecated environment variable.  This is implemented in a way that
+        // cargo-insta can support older and newer insta versions alike.  It will set both
+        // variables.  However if only `INSTA_FORCE_UPDATE_SNAPSHOTS` is set, we will emit
+        // a deprecation warning.
+        if env::var("INSTA_FORCE_UPDATE").is_err() {
+            if let Ok("1") = env::var("INSTA_FORCE_UPDATE_SNAPSHOTS").as_deref() {
+                eprintln!("INSTA_FORCE_UPDATE_SNAPSHOTS is deprecated, use INSTA_FORCE_UPDATE");
+                env::set_var("INSTA_FORCE_UPDATE", "1");
+            }
         }
 
         Ok(ToolConfig {


### PR DESCRIPTION
Restores support for older insta versions in cargo insta broken by #449.