### PR TITLE
Allow trailing commas to work for file snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.37.0
+
+- All macros should now handle trailing commas.
+
 ## 1.36.1
 
 - Fix an ownership issue introduced in 1.36 with snapshot assertions.  #453

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.37.0
 
-- All macros should now handle trailing commas.
+- All macros for file snapshots should now handle trailing commas (but not yet inline snapshots)
 
 ## 1.36.1
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -219,7 +219,7 @@ macro_rules! assert_compact_json_snapshot {
     };
 }
 
-// This macro is expected to handle optional trailing commas.
+// The macro handles optional trailing commas for file snapshots.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_serialized_snapshot {
@@ -228,7 +228,8 @@ macro_rules! _assert_serialized_snapshot {
     //
     // Note that if we could unify the Inline & File represenations of snapshots
     // redactions we could unify some of these branches.
-    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?}, @$snapshot:literal $(,)?) => {{
+
+    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?}, @$snapshot:literal) => {{
         let transform = |value| {
             let (_, value) = $crate::_prepare_snapshot_for_redaction!(value, {$($k => $v),*}, $format, Inline);
             value
@@ -249,7 +250,8 @@ macro_rules! _assert_serialized_snapshot {
     }};
     // If there's an inline snapshot, capture serialization function and pass to
     // `_assert_snapshot_base`, specifying `Inline`
-      (format=$format:ident, $($arg:expr),*, @$snapshot:literal) => {{
+    //
+    (format=$format:ident, $($arg:expr),*, @$snapshot:literal) => {{
         let transform = |value| {$crate::_macro_support::serialize_value(
             &value,
             $crate::_macro_support::SerializationFormat::$format,
@@ -319,7 +321,7 @@ macro_rules! assert_debug_snapshot {
 // the value. This allows us to implement other macros with a small wrapper. All
 // snapshot macros eventually call this macro.
 //
-// This macro is expected to handle trailing commas.
+// The macro handles optional trailing commas in file snapshots.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_snapshot_base {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -219,6 +219,7 @@ macro_rules! assert_compact_json_snapshot {
     };
 }
 
+// This macro is expected to handle optional trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_serialized_snapshot {
@@ -227,7 +228,7 @@ macro_rules! _assert_serialized_snapshot {
     //
     // Note that if we could unify the Inline & File represenations of snapshots
     // redactions we could unify some of these branches.
-    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}, @$snapshot:literal) => {{
+    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?}, @$snapshot:literal $(,)?) => {{
         let transform = |value| {
             let (_, value) = $crate::_prepare_snapshot_for_redaction!(value, {$($k => $v),*}, $format, Inline);
             value
@@ -235,11 +236,11 @@ macro_rules! _assert_serialized_snapshot {
         $crate::_assert_snapshot_base!(transform=transform, $value, @$snapshot);
     }};
     // If there are redaction expressions and no name, add a auto-generated name, call self
-    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
+    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?} $(,)?) => {{
         $crate::_assert_serialized_snapshot!(format=$format, $crate::_macro_support::AutoName, $value, {$($k => $v),*});
     }};
     // If there are redaction expressions, capture and pass to `_assert_snapshot_base`
-    (format=$format:ident, $name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),*$(,)?}) => {{
+    (format=$format:ident, $name:expr, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?} $(,)?) => {{
         let transform = |value| {
             let (_, value) = $crate::_prepare_snapshot_for_redaction!(value, {$($k => $v),*}, $format, File);
             value
@@ -257,7 +258,7 @@ macro_rules! _assert_serialized_snapshot {
         $crate::_assert_snapshot_base!(transform = transform, $($arg),*, @$snapshot);
     }};
     // Capture serialization function and pass to `_assert_snapshot_base`,
-    // specifing `File`
+    // specifying `File`
     (format=$format:ident, $($arg:expr),* $(,)?) => {{
         let transform = |value| {$crate::_macro_support::serialize_value(
             &value,
@@ -272,7 +273,7 @@ macro_rules! _assert_serialized_snapshot {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _prepare_snapshot_for_redaction {
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, $format:ident, $location:ident) => {
+    ($value:expr, {$($k:expr => $v:expr),*}, $format:ident, $location:ident) => {
         {
             let vec = vec![
                 $((
@@ -295,7 +296,7 @@ macro_rules! _prepare_snapshot_for_redaction {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _prepare_snapshot_for_redaction {
-    ($value:expr, {$($k:expr => $v:expr),*$(,)?}, $format:ident, $location:ident) => {
+    ($value:expr, {$($k:expr => $v:expr),*}, $format:ident, $location:ident) => {
         compile_error!("insta was compiled without redaction support.");
     };
 }
@@ -315,13 +316,16 @@ macro_rules! assert_debug_snapshot {
 }
 
 // A helper macro which takes a closure as `transform`, and runs the closure on
-// the value. This allows us to implement other macros with a small wrapper.
+// the value. This allows us to implement other macros with a small wrapper. All
+// snapshot macros eventually call this macro.
+//
+// This macro is expected to handle trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_snapshot_base {
     // If there's an inline literal value, wrap the literal in a
     // `ReferenceValue::Inline`, call self.
-    (transform=$transform:expr, $($arg:expr),*, @$snapshot:literal) => {
+    (transform=$transform:expr, $($arg:expr),*, @$snapshot:literal $(,)?) => {
         $crate::_assert_snapshot_base!(
             transform = $transform,
             #[allow(clippy::needless_raw_string_hashes)]
@@ -330,12 +334,12 @@ macro_rules! _assert_snapshot_base {
         )
     };
     // If there's no debug_expr, use the stringified value, call self.
-    (transform=$transform:expr, $name:expr, $value:expr) => {
+    (transform=$transform:expr, $name:expr, $value:expr $(,)?) => {
         $crate::_assert_snapshot_base!(transform = $transform, $name, $value, stringify!($value))
     };
     // If there's no name (and necessarily no debug expr), auto generate the
     // name, call self.
-    (transform=$transform:expr, $value:expr) => {
+    (transform=$transform:expr, $value:expr $(,)?) => {
         $crate::_assert_snapshot_base!(
             transform = $transform,
             $crate::_macro_support::AutoName,
@@ -343,7 +347,7 @@ macro_rules! _assert_snapshot_base {
         )
     };
     // The main macro body — every call to this macro should end up here.
-    (transform=$transform:expr, $name:expr, $value:expr, $debug_expr:expr) => {
+    (transform=$transform:expr, $name:expr, $value:expr, $debug_expr:expr $(,)?) => {
         $crate::_macro_support::assert_snapshot(
             $name.into(),
             #[allow(clippy::redundant_closure_call)]

--- a/tests/snapshots/test_basic__Testing.snap
+++ b/tests/snapshots/test_basic__Testing.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_basic.rs
+expression: expr
+---
+name

--- a/tests/snapshots/test_basic__trailing_commas-2.snap
+++ b/tests/snapshots/test_basic__trailing_commas-2.snap
@@ -1,0 +1,9 @@
+---
+source: tests/test_basic.rs
+expression: "vec![1, 2, 3, 4, 5]"
+---
+- 1
+- 2
+- 3
+- 4
+- 5

--- a/tests/snapshots/test_basic__trailing_commas.snap
+++ b/tests/snapshots/test_basic__trailing_commas.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_basic.rs
+expression: "\"Testing\""
+---
+Testing

--- a/tests/snapshots/test_redaction__with_random_value_and_match_comma-2.snap
+++ b/tests/snapshots/test_redaction__with_random_value_and_match_comma-2.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 11,\n        username: \"john_doe\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+id: "[id]"
+username: john_doe
+email: john@example.com
+extra: ""

--- a/tests/snapshots/test_redaction__with_random_value_and_match_comma.snap
+++ b/tests/snapshots/test_redaction__with_random_value_and_match_comma.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_redaction.rs
+expression: "&User {\n        id: 11,\n        username: \"john_doe\".to_string(),\n        email: Email(\"john@example.com\".to_string()),\n        extra: \"\".to_string(),\n    }"
+---
+id: "[id]"
+username: john_doe
+email: john@example.com
+extra: ""

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -3,7 +3,7 @@ use insta::assert_json_snapshot;
 #[cfg(feature = "yaml")]
 use insta::assert_yaml_snapshot;
 #[allow(deprecated)]
-use insta::{assert_debug_snapshot, assert_display_snapshot};
+use insta::{assert_debug_snapshot, assert_display_snapshot, assert_snapshot};
 use std::fmt;
 
 #[test]
@@ -61,6 +61,13 @@ mod nested {
     fn test_nested_module() {
         insta::assert_snapshot!("aoeu");
     }
+}
+
+#[test]
+fn test_trailing_commas() {
+    assert_snapshot!("Testing",);
+    assert_snapshot!("Testing", "name",);
+    assert_snapshot!("Testing", "name", "expr",);
 }
 
 struct TestDisplay;

--- a/tests/test_basic.rs
+++ b/tests/test_basic.rs
@@ -68,6 +68,8 @@ fn test_trailing_commas() {
     assert_snapshot!("Testing",);
     assert_snapshot!("Testing", "name",);
     assert_snapshot!("Testing", "name", "expr",);
+    #[cfg(feature = "yaml")]
+    assert_yaml_snapshot!(vec![1, 2, 3, 4, 5],);
 }
 
 struct TestDisplay;

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -30,14 +30,6 @@ fn test_single_line() {
 }
 
 #[test]
-fn test_trailing_commas() {
-    assert_snapshot!(
-        "Testing",
-        @"Testing",
-    );
-}
-
-#[test]
 fn test_unnamed_single_line() {
     assert_snapshot!("Testing");
     assert_snapshot!("Testing-2");

--- a/tests/test_inline.rs
+++ b/tests/test_inline.rs
@@ -30,6 +30,14 @@ fn test_single_line() {
 }
 
 #[test]
+fn test_trailing_commas() {
+    assert_snapshot!(
+        "Testing",
+        @"Testing",
+    );
+}
+
+#[test]
 fn test_unnamed_single_line() {
     assert_snapshot!("Testing");
     assert_snapshot!("Testing-2");

--- a/tests/test_redaction.rs
+++ b/tests/test_redaction.rs
@@ -88,7 +88,7 @@ fn test_with_random_value_and_trailing_comma() {
 
 #[cfg(feature = "yaml")]
 #[test]
-fn test_with_random_value_and_trailing_comma_match() {
+fn test_with_random_value_and_match_comma() {
     assert_yaml_snapshot!(
         &User {
             id: 11,
@@ -99,6 +99,35 @@ fn test_with_random_value_and_trailing_comma_match() {
         match .. {
             ".id" => "[id]",
         }
+    );
+    assert_yaml_snapshot!(
+        &User {
+            id: 11,
+            username: "john_doe".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        }, // comma here
+    );
+    assert_yaml_snapshot!(
+        &User {
+            id: 11,
+            username: "john_doe".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        },
+        @r###"
+        ---
+        id: "[id]"
+        username: john_doe
+        email: john@example.com
+        extra: ""
+        "###, // comma here
     );
 }
 

--- a/tests/test_redaction.rs
+++ b/tests/test_redaction.rs
@@ -111,24 +111,6 @@ fn test_with_random_value_and_match_comma() {
             ".id" => "[id]",
         }, // comma here
     );
-    assert_yaml_snapshot!(
-        &User {
-            id: 11,
-            username: "john_doe".to_string(),
-            email: Email("john@example.com".to_string()),
-            extra: "".to_string(),
-        },
-        match .. {
-            ".id" => "[id]",
-        },
-        @r###"
-        ---
-        id: "[id]"
-        username: john_doe
-        email: john@example.com
-        extra: ""
-        "###, // comma here
-    );
 }
 
 #[cfg(feature = "csv")]


### PR DESCRIPTION
This was implemented for some macros but not others (possibly this was my mistake when simplifying the macros...). This centralizes their handling in two central macros.

Inline macros don't work, because of how we replace the values, so we still need to fix those. But I ran out of time on this so pushed the partial fix.