### PR TITLE
chore: replace unmaintained yaml-rust dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }
 regex = { version = "1.6.0", default-features = false, optional = true, features = ["std", "unicode"] }
-yaml-rust = "0.4.5"
+yaml-rust2 = "0.7"
 serde = { version = "1.0.117", optional = true }
 linked-hash-map = "0.5.6"
 lazy_static = "1.4.0"


### PR DESCRIPTION
## Description:

yaml-rust seems unmaintained and has an advisory against it. This is now causing `cargo deny` to fail in our CI. https://rustsec.org/advisories/RUSTSEC-2024-0320