### PR TITLE
Allow trailing commas in inline snapshots

### DIFF
--- a/cargo-insta/src/inline.rs
+++ b/cargo-insta/src/inline.rs
@@ -171,6 +171,14 @@ impl FilePatcher {
             }
 
             fn try_extract_snapshot(&mut self, tokens: &[TokenTree], indentation: usize) -> bool {
+                // ignore optional trailing comma
+                let tokens = match tokens.last() {
+                    Some(TokenTree::Punct(ref punct)) if punct.as_char() == ',' => {
+                        &tokens[..tokens.len() - 1]
+                    }
+                    _ => tokens,
+                };
+
                 if tokens.len() < 2 {
                     return false;
                 }

--- a/cargo-insta/tests/snapshots/main__test_basic_utf8_inline.snap
+++ b/cargo-insta/tests/snapshots/main__test_basic_utf8_inline.snap
@@ -1,7 +1,6 @@
 ---
-source: src/main.rs
+source: cargo-insta/tests/main.rs
 expression: "&fs::read_to_string(gen_file).unwrap()"
-input_file: tests/test_basic_utf8_inline.rs
 ---
 #[test]
 #[rustfmt::skip]
@@ -22,3 +21,10 @@ fn test_remove_existing_value_multiline() {
     );
 }
 
+#[test]
+fn test_trailing_comma_in_inline_snapshot() {
+    insta::assert_snapshot!(
+        "new value",
+        @"new value",  // comma here
+    );
+}

--- a/cargo-insta/tests/snapshots/main__test_json_inline.snap
+++ b/cargo-insta/tests/snapshots/main__test_json_inline.snap
@@ -1,7 +1,6 @@
 ---
-source: src/main.rs
+source: cargo-insta/tests/main.rs
 expression: "&fs::read_to_string(gen_file).unwrap()"
-input_file: tests/test_json_inline.rs
 ---
 use serde::Serialize;
 
@@ -27,3 +26,34 @@ fn test_json_snapshot() {
     "###);
 }
 
+#[test]
+fn test_json_snapshot_trailing_comma() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_compact_json_snapshot!(
+        &user,
+        @r###"{"id": 42, "email": "john.doe@example.com"}"###,
+    );
+}
+
+#[test]
+fn test_json_snapshot_trailing_comma_redaction() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_json_snapshot!(
+        &user,
+        {
+            ".id" => "[user_id]",
+        },
+        @r###"
+    {
+      "id": "[user_id]",
+      "email": "john.doe@example.com"
+    }
+    "###,
+    );
+}

--- a/cargo-insta/tests/snapshots/main__test_yaml_inline.snap
+++ b/cargo-insta/tests/snapshots/main__test_yaml_inline.snap
@@ -1,7 +1,6 @@
 ---
-source: src/main.rs
+source: cargo-insta/tests/main.rs
 expression: "&fs::read_to_string(gen_file).unwrap()"
-input_file: tests/test_yaml_inline.rs
 ---
 use serde::Serialize;
 
@@ -26,3 +25,21 @@ fn test_yaml_snapshot() {
     "###);
 }
 
+#[test]
+fn test_yaml_snapshot_trailing_comma() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_yaml_snapshot!(
+        &user,
+        {
+            ".id" => "[user_id]",
+        },
+        @r###"
+    ---
+    id: "[user_id]"
+    email: john.doe@example.com
+    "###,
+    );
+}

--- a/cargo-insta/tests/test-input/test_basic_utf8_inline.rs
+++ b/cargo-insta/tests/test-input/test_basic_utf8_inline.rs
@@ -18,3 +18,11 @@ fn test_remove_existing_value_multiline() {
         it really is"
     );
 }
+
+#[test]
+fn test_trailing_comma_in_inline_snapshot() {
+    insta::assert_snapshot!(
+        "new value",
+        @"old value",  // comma here
+    );
+}

--- a/cargo-insta/tests/test-input/test_json_inline.rs
+++ b/cargo-insta/tests/test-input/test_json_inline.rs
@@ -16,3 +16,30 @@ fn test_json_snapshot() {
         ".id" => "[user_id]",
     }, @"");
 }
+
+#[test]
+fn test_json_snapshot_trailing_comma() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_compact_json_snapshot!(
+        &user,
+        @"",
+    );
+}
+
+#[test]
+fn test_json_snapshot_trailing_comma_redaction() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_json_snapshot!(
+        &user,
+        {
+            ".id" => "[user_id]",
+        },
+        @"",
+    );
+}

--- a/cargo-insta/tests/test-input/test_yaml_inline.rs
+++ b/cargo-insta/tests/test-input/test_yaml_inline.rs
@@ -16,3 +16,18 @@ fn test_yaml_snapshot() {
         ".id" => "[user_id]",
     }, @"");
 }
+
+#[test]
+fn test_yaml_snapshot_trailing_comma() {
+    let user = User {
+        id: 42,
+        email: "john.doe@example.com".into(),
+    };
+    insta::assert_yaml_snapshot!(
+        &user,
+        {
+            ".id" => "[user_id]",
+        },
+        @"",
+    );
+}

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -219,7 +219,7 @@ macro_rules! assert_compact_json_snapshot {
     };
 }
 
-// The macro handles optional trailing commas for file snapshots.
+// This macro is expected to handle optional trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_serialized_snapshot {
@@ -228,8 +228,7 @@ macro_rules! _assert_serialized_snapshot {
     //
     // Note that if we could unify the Inline & File represenations of snapshots
     // redactions we could unify some of these branches.
-
-    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?}, @$snapshot:literal) => {{
+    (format=$format:ident, $value:expr, $(match ..)? {$($k:expr => $v:expr),* $(,)?}, @$snapshot:literal $(,)?) => {{
         let transform = |value| {
             let (_, value) = $crate::_prepare_snapshot_for_redaction!(value, {$($k => $v),*}, $format, Inline);
             value
@@ -250,8 +249,7 @@ macro_rules! _assert_serialized_snapshot {
     }};
     // If there's an inline snapshot, capture serialization function and pass to
     // `_assert_snapshot_base`, specifying `Inline`
-    //
-    (format=$format:ident, $($arg:expr),*, @$snapshot:literal) => {{
+    (format=$format:ident, $($arg:expr),*, @$snapshot:literal $(,)?) => {{
         let transform = |value| {$crate::_macro_support::serialize_value(
             &value,
             $crate::_macro_support::SerializationFormat::$format,
@@ -321,7 +319,7 @@ macro_rules! assert_debug_snapshot {
 // the value. This allows us to implement other macros with a small wrapper. All
 // snapshot macros eventually call this macro.
 //
-// The macro handles optional trailing commas in file snapshots.
+// This macro is expected to handle trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_snapshot_base {

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -219,7 +219,7 @@ macro_rules! assert_compact_json_snapshot {
     };
 }
 
-// This macro is expected to handle optional trailing commas.
+// This macro handles optional trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_serialized_snapshot {
@@ -319,7 +319,7 @@ macro_rules! assert_debug_snapshot {
 // the value. This allows us to implement other macros with a small wrapper. All
 // snapshot macros eventually call this macro.
 //
-// This macro is expected to handle trailing commas.
+// This macro handles optional trailing commas.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _assert_snapshot_base {

--- a/insta/tests/test_inline.rs
+++ b/insta/tests/test_inline.rs
@@ -25,6 +25,14 @@ fn test_simple() {
 }
 
 #[test]
+fn test_trailing_commas() {
+    assert_snapshot!(
+        "Testing",
+        @"Testing",
+    );
+}
+
+#[test]
 fn test_single_line() {
     assert_snapshot!("Testing", @"Testing");
 }

--- a/insta/tests/test_redaction.rs
+++ b/insta/tests/test_redaction.rs
@@ -111,6 +111,24 @@ fn test_with_random_value_and_match_comma() {
             ".id" => "[id]",
         }, // comma here
     );
+    assert_yaml_snapshot!(
+        &User {
+            id: 11,
+            username: "john_doe".to_string(),
+            email: Email("john@example.com".to_string()),
+            extra: "".to_string(),
+        },
+        match .. {
+            ".id" => "[id]",
+        },
+        @r###"
+        ---
+        id: "[id]"
+        username: john_doe
+        email: john@example.com
+        extra: ""
+        "###, // comma here
+    );
 }
 
 #[cfg(feature = "csv")]


### PR DESCRIPTION
After using https://github.com/mitsuhiko/insta-cmd/pull/12 for a bit, I noticed that `cargo insta test` would not pick up on mismatches in inline snapshots with trailing commas.

This PR fixes that and also allows trailing commas for inline snapshots in other macros.

This PR uses code from #454 by @max-sixty.