### PR TITLE
Fix VSCode plugin not recognizing crates in subfolders

### DIFF
--- a/vscode-insta/package.json
+++ b/vscode-insta/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/mitsuhiko/insta",
   "icon": "images/icon.png",
   "activationEvents": [
-    "workspaceContains:Cargo.toml",
+    "workspaceContains:Cargo.lock",
     "onLanguage:rust",
     "onLanguage:insta-snapshots",
     "onView:pendingInstaSnapshots",

--- a/vscode-insta/src/cargo.ts
+++ b/vscode-insta/src/cargo.ts
@@ -15,7 +15,7 @@ function metadataReferencesInsta(metadata: any): boolean {
   return false;
 }
 
-export async function projectUsesInsta(root: Uri): Promise<boolean> {
+async function checkSingleProject(root: Uri): Promise<boolean> {
   const rootCargoToml = Uri.joinPath(root, "Cargo.toml");
   try {
     await workspace.fs.stat(rootCargoToml);
@@ -43,4 +43,17 @@ export async function projectUsesInsta(root: Uri): Promise<boolean> {
       }
     });
   });
+}
+
+export async function projectUsesInsta(roots: Uri[]): Promise<boolean> {
+  const results = await Promise.all(roots.map(checkSingleProject));
+  return results.some((x) => x);
+}
+
+export async function findCargoRoots(): Promise<Uri[]> {
+  // we search for the lockfile to only include workspace roots
+  const uris = await workspace.findFiles('**/Cargo.lock');
+  const roots = uris.map((uri) => Uri.joinPath(uri, '..'));
+  console.log('found cargo roots', roots);
+  return roots;
 }


### PR DESCRIPTION
This is a naive implementation where we just search for cargo lockfiles to find cargo roots.
It's good enough imo and isn't much worse than the previous impl

Closes #471