### PR TITLE
Fix `require-full-match` working without cargo-insta on inline snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Print a clearer error message when accepting a snapshot that was removed.  #516
 
+- Fix `require-full-match` when running on inline snapshots outside of `cargo insta`.  #496
+
 ## 1.39.0
 
 - Fixed a bug in `require_full_match`.  #485

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -642,6 +642,7 @@ pub fn assert_snapshot(
         assertion_file,
         assertion_line,
     )?;
+
     let tool_config = get_tool_config(manifest_dir);
 
     // apply filters if they are available

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -250,6 +250,17 @@ impl MetaData {
     /// Trims the metadata of fields that we don't save to `.snap` files; we
     /// only use for display while reviewing
     fn trim_for_persistence(&self) -> Cow<'_, MetaData> {
+        let is_inline = self.input_file.is_none();
+        // If it's inline, we don't persist any metadata
+        if is_inline {
+            return Cow::Owned(MetaData {
+                source: None,
+                assertion_line: None,
+                input_file: None,
+                expression: None,
+                ..self.clone()
+            });
+        }
         if self.assertion_line.is_some() {
             let mut rv = self.clone();
             rv.assertion_line = None;


### PR DESCRIPTION
Running `require-full-match` without `cargo-insta` (or with `cargo insta --check`) wasn't working on inline snapshots, since those snapshots don't have metadata.

I'm also going to PR to make `require-full-match` experimental, since I've also found some corner cases where it doesn't work yet.
