### PR TITLE
Mark `require-full-match` as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Print a clearer error message when accepting a snapshot that was removed.  #516
 
+- Mark `require-full-match` as experimental, given some corner-cases are currently difficult to manage.  #497
+
 ## 1.39.0
 
 - Fixed a bug in `require_full_match`.  #485
@@ -41,7 +43,7 @@ All notable changes to insta and cargo-insta are documented here.
 - Deprecate `INSTA_FORCE_UPDATE_SNAPSHOTS` env-var for `INSTA_FORCE_UPDATE`.
   The latter was documented, the former was implemented.  #449
 
-- Add `require_full_match` option.  #448 
+- Add `require_full_match` option.  #448
 
 - Deprecate `assert_display_snapshot!`.  #385
 

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -186,7 +186,7 @@ struct TestCommand {
     /// Update all snapshots even if they are still matching.
     #[structopt(long)]
     force_update_snapshots: bool,
-    /// Require metadata as well as snapshots' contents to match.
+    /// Require metadata as well as snapshots' contents to match (experimental).
     #[structopt(long)]
     require_full_match: bool,
     /// Handle unreferenced snapshots after a successful test run.
@@ -890,9 +890,6 @@ fn prepare_test_runner<'snapshot_ref>(
         proc.env("INSTA_FORCE_UPDATE_SNAPSHOTS", "1");
         // for newer versions of insta
         proc.env("INSTA_FORCE_UPDATE", "1");
-    }
-    if cmd.require_full_match {
-        proc.env("INSTA_REQUIRE_FULL_MATCH", "1");
     }
     if cmd.require_full_match {
         proc.env("INSTA_REQUIRE_FULL_MATCH", "1");


### PR DESCRIPTION
I did some more testing. There are some corner-cases where it doesn't work; for example if `info` is used it fails, because our serializer / deserializer doesn't roundtrip.

For example; from the insta tests, One is `Map`; the other a `Struct`:

```
[insta/src/snapshot.rs:440:20] self.metadata.trim_for_persistence() = MetaData {
    source: None,
    assertion_line: None,
    description: Some(
        "The snapshot is four integers",
    ),
    expression: None,
    info: Some(
        Map(
            [
                (
                    String(
                        "env",
                    ),
                    Map(
                        [
                            (
                                String(
                                    "ENVIRONMENT",
                                ),
                                String(
                                    "production",
                                ),
                            ),
                        ],
                    ),
                ),
                (
                    String(
                        "cmdline",
                    ),
                    Seq(
                        [
                            String(
                                "my-tool",
                            ),
                            String(
                                "run",
                            ),
                        ],
                    ),
                ),
            ],
        ),
    ),
    input_file: None,
}
[insta/src/snapshot.rs:441:24] other.metadata.trim_for_persistence() = MetaData {
    source: None,
    assertion_line: None,
    description: Some(
        "The snapshot is four integers",
    ),
    expression: None,
    info: Some(
        Struct(
            "Info",
            [
                (
                    "env",
                    Map(
                        [
                            (
                                String(
                                    "ENVIRONMENT",
                                ),
                                String(
                                    "production",
                                ),
                            ),
                        ],
                    ),
                ),
                (
                    "cmdline",
                    Seq(
                        [
                            String(
                                "my-tool",
                            ),
                            String(
                                "run",
                            ),
                        ],
                    ),
                ),
            ],
        ),
    ),
    input_file: None,
}
```
