### PR TITLE
Print a warning for old snapshot formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.40.0
 
-- Print a warning for old inline snapshot formats.
+- Print a warning when encountering old snapshot formats.  #503
 
 ## 1.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.40.0
+
+- Print a warning for old inline snapshot formats.
+
 ## 1.39.0
 
 - Fixed a bug in `require_full_match`.  #485

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -313,6 +313,7 @@ impl Snapshot {
                     }
                 }
             }
+            eprintln!("A snapshot uses an old snapshot format; please update it to the new format with `cargo insta --force-update-snapshots.\n\nSnapshot is at: {}", p.to_string_lossy());
             rv
         };
 
@@ -670,7 +671,7 @@ fn get_inline_snapshot_value(frozen_value: &str) -> String {
     // (the only call site)
 
     if frozen_value.trim_start().starts_with('⋮') {
-        eprintln!("Value uses an old snapshot format; please update it to the new format with `cargo insta --force-update-snapshots.\n\nValue: {}", frozen_value);
+        eprintln!("A snapshot uses an old snapshot format; please update it to the new format with `cargo insta --force-update-snapshots.\n\nValue: {}", frozen_value);
 
         // legacy format - retain so old snapshots still work
         let mut buf = String::new();

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -670,6 +670,8 @@ fn get_inline_snapshot_value(frozen_value: &str) -> String {
     // (the only call site)
 
     if frozen_value.trim_start().starts_with('⋮') {
+        eprintln!("Value uses an old snapshot format; please update it to the new format with `cargo insta --force-update-snapshots.\n\nValue: {}", frozen_value);
+
         // legacy format - retain so old snapshots still work
         let mut buf = String::new();
         let mut line_iter = frozen_value.lines();


### PR DESCRIPTION
Would be nice to remove this sort of code at some point. Maybe we need to wait for 2.0 though. But either way, this encourages updating to newer formats.
