### PR TITLE
Run the in-tree version of cargo-insta in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,19 @@ jobs:
       - name: Test
         run: make test
 
+  test-current-cargo-insta:
+    name: Run the in-tree version of cargo-insta on ourselves
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Test
+        run: cargo run -p cargo-insta -- test
+
   test-stable:
     name: Test on 1.61.0
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've been using this approach to test `cargo-insta` locally; would it make a reasonable test for CI too?
