### PR TITLE
Raise an error on sufficiently different `insta` vs `cargo-insta` versions

### DIFF
--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -24,6 +24,8 @@ syn = { version = "1.0.50", features = ["full", "visit", "extra-traits"] }
 ignore = "0.4.17"
 uuid = { version = "1.0.0", features = ["v4"] }
 tempfile = "3.5.0"
+semver = {version = "1.0.23", features = ["serde"]}
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 walkdir = "2.3.1"


### PR DESCRIPTION
This has two purposes:
- By raising an error if major versions differ, it allows eventually upgrading to insta 2 without confusing breaks (we want to add this sufficiently before releasing v2)
- It potentially allows for making some changes before a big break, by warning when minor versions differ sufficiently. This could be upgraded to an error. Currently we have a few deprecated items; and I was thinking of trying to unify some of the pending / named snapshot handling, but it becomes burdensome if we need to support the existing approach forever.

WDYT?
