### PR TITLE
feat: add `assert_compact_debug_snapshot`

### DIFF
--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -308,8 +308,6 @@ macro_rules! _prepare_snapshot_for_redaction {
 /// permit redactions.
 ///
 /// Debug is called with `"{:#?}"`, which means this uses pretty-print.
-///
-/// See also [`assert_compact_debug_snapshot!`].
 #[macro_export]
 macro_rules! assert_debug_snapshot {
     ($($arg:tt)*) => {
@@ -324,8 +322,6 @@ macro_rules! assert_debug_snapshot {
 /// permit redactions.
 ///
 /// Debug is called with `"{:?}"`, which means this does not use pretty-print.
-///
-/// See also [`assert_debug_snapshot!`].
 #[macro_export]
 macro_rules! assert_compact_debug_snapshot {
     ($($arg:tt)*) => {

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -308,10 +308,28 @@ macro_rules! _prepare_snapshot_for_redaction {
 /// permit redactions.
 ///
 /// Debug is called with `"{:#?}"`, which means this uses pretty-print.
+///
+/// See also [`assert_compact_debug_snapshot!`].
 #[macro_export]
 macro_rules! assert_debug_snapshot {
     ($($arg:tt)*) => {
         $crate::_assert_snapshot_base!(transform=|v| std::format!("{:#?}", v), $($arg)*)
+    };
+}
+
+/// Asserts a `Debug` snapshot in compact format.
+///
+/// The value needs to implement the `fmt::Debug` trait.  This is useful for
+/// simple values that do not implement the `Serialize` trait, but does not
+/// permit redactions.
+///
+/// Debug is called with `"{:?}"`, which means this does not use pretty-print.
+///
+/// See also [`assert_debug_snapshot!`].
+#[macro_export]
+macro_rules! assert_compact_debug_snapshot {
+    ($($arg:tt)*) => {
+        $crate::_assert_snapshot_base!(transform=|v| std::format!("{:?}", v), $($arg)*)
     };
 }
 

--- a/insta/tests/test_inline.rs
+++ b/insta/tests/test_inline.rs
@@ -9,7 +9,7 @@ use insta::assert_yaml_snapshot;
 #[cfg(feature = "json")]
 use insta::{assert_compact_json_snapshot, assert_json_snapshot};
 
-use insta::{assert_debug_snapshot, assert_snapshot};
+use insta::{assert_compact_debug_snapshot, assert_debug_snapshot, assert_snapshot};
 use std::thread;
 
 #[test]
@@ -279,6 +279,12 @@ fn test_compact_json() {
       33
     ]
     "###);
+}
+
+#[test]
+fn test_compact_debug() {
+    assert_compact_debug_snapshot!((1..30).collect::<Vec<_>>(), @"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29]");
+    assert_compact_debug_snapshot!((1..34).collect::<Vec<_>>(), @"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]");
 }
 
 #[test]


### PR DESCRIPTION
The pretty-print format of debug is generally extremely verbose. It's great for complex objects, but for simple ones, the compact form of debug is far more suitable. This PR adds a `assert_compact_debug_snapshot` similar to `assert_compact_json_snapshot`.