### PR TITLE
Print a better message when running with `--check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.40.0
 
+- No longer suggest running `cargo insta` message when running `cargo insta test --check`.  #515
+
 - Print a clearer error message when accepting a snapshot that was removed.  #516
 
 ## 1.39.0

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -812,6 +812,9 @@ fn prepare_test_runner<'snapshot_ref>(
         }
     };
 
+    // An env var to indicate we're running under cargo-insta
+    proc.env("INSTA_CARGO_INSTA", "1");
+
     let snapshot_ref_file = if unreferenced != UnreferencedSnapshots::Ignore {
         match snapshot_ref_file {
             Some(path) => Some(Cow::Borrowed(path)),

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -7,6 +6,7 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::str;
 use std::sync::{Arc, Mutex};
+use std::{borrow::Cow, env};
 
 use crate::env::{
     get_cargo_workspace, get_tool_config, memoize_snapshot_file, snapshot_update_behavior,
@@ -526,13 +526,12 @@ fn finalize_assertion(ctx: &SnapshotAssertionContext, update_result: SnapshotUpd
 
     if update_result != SnapshotUpdateBehavior::InPlace && !ctx.tool_config.force_pass() {
         if fail_fast && ctx.tool_config.output_behavior() != OutputBehavior::Nothing {
-            println!(
-                "{hint}",
-                hint = style(
-                    "Stopped on the first failure. Run `cargo insta test` to run all snapshots."
-                )
-                .dim(),
-            );
+            let msg = if env::var("INSTA_CARGO_INSTA") == Ok("1".to_string()) {
+                "Stopped on the first failure."
+            } else {
+                "Stopped on the first failure. Run `cargo insta test` to run all snapshots."
+            };
+            println!("{hint}", hint = style(msg).dim(),);
         }
 
         // if we are in glob mode, count the failures and print the


### PR DESCRIPTION
Use an env var to indicate when we're running with `cargo insta`, don't suggest to do so if we already are

(I may try and change what `--check` does — don't think in necessarily needs to fail fast, but this fixes the message for now)
