### PR TITLE
Report missing file when accepting snapshot

### DIFF
--- a/cargo-insta/src/container.rs
+++ b/cargo-insta/src/container.rs
@@ -212,7 +212,10 @@ impl SnapshotContainer {
             for snapshot in self.snapshots.iter() {
                 match snapshot.op {
                     Operation::Accept => {
-                        let snapshot = Snapshot::from_file(&self.snapshot_path)?;
+                        let snapshot = Snapshot::from_file(&self.snapshot_path).map_err(|e| {
+                            let error = *e.downcast::<std::io::Error>().unwrap();
+                            ContentError::FileIo(error, self.snapshot_path.to_path_buf())
+                        })?;
                         snapshot.save(&self.target_path)?;
                         try_removing_snapshot(&self.snapshot_path);
                     }


### PR DESCRIPTION
This previously failed with a cryptic `error: No such file or directory (os error 2)`.

It now fails with the slightly less cryptic `error: File error for '/Users/maximilian/workspace/prql/prqlc/prqlc/tests/integration/snapshots/integration__queries__debug_lineage__genre_counts.snap.new': No such file or directory (os error 2)`

This happens when accepting a snapshot, which causes a watching process to re-run, which then clears pending snapshots. That process is being too aggressive about clearing pending snapshots, but that's another issue
