### PR TITLE
Bump `pest` versions

### DIFF
--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -50,8 +50,8 @@ _cargo_insta_internal = []
 [dependencies]
 dep_csv = { package = "csv", version = "=1.1.6", optional = true }
 console = { version = "0.15.4", optional = true, default-features = false }
-pest = { version = "2.1.3", optional = true }
-pest_derive = { version = "2.1.0", optional = true }
+pest = { version = "2.4.0", optional = true }
+pest_derive = { version = "2.4.0", optional = true }
 dep_ron = { package = "ron", version = "0.7.1", optional = true }
 dep_toml = { package = "toml", version = "0.5.7", optional = true }
 globset = { version = "0.4.6", optional = true }


### PR DESCRIPTION
Because older versions of pest can support really old versions of `proc-macro2`, this was causing some errors in min-versions checks (for example https://github.com/mitsuhiko/insta/actions/runs/9829003042/job/27133598634?pr=518#step:6:229).

It doesn't solve any 'actual' problems, it just fixes the checks, but it's also very low cost. Pest 2.4.0 was out two years ago
