### PR TITLE
Check whether building without a cache passes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,13 @@ jobs:
         run: make test
 
   test-temp-no-cache:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Test
         run: make test
 
+  test-temp-no-cache:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Test
+        run: make test
+
   test-stable:
     name: Test on 1.61.0
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently when I run `cargo update && cargo build` locally, I get failures around `similar 2.5.0`. I'm not sure why CI has been passing; this is a test to check whether it's the cache which is holding an existing version of dependencies.

#524 adds the lockfile to the repo, which would reduce the change of a local dev break
