### PR TITLE
docs: Update CHANGELOG for assert_compact_debug_snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.40.0
 
+- Added support for compact debug snapshots (`assert_compact_debug_snapshot`). #514
+
 - Inline snapshots now use the required number of `#`s to escape the snapshot
   value, rather than always using `###`. This allows snapshotting values which
   themselves contain `###`. If there are no existing `#` characters in the


### PR DESCRIPTION
This follows up https://github.com/mitsuhiko/insta/pull/514 and use the same pattern of:

> Added support for compact JSON snapshots. (#288)

@max-sixty 