### PR TITLE
Don't enforce locking in Cargo.toml

### DIFF
--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -21,13 +21,13 @@ serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 proc-macro2 = { version = "1.0.60", features = ["span-locations"] }
 # Pinned because of MSRV; wait for MSRV bump or msrv-resolver
-syn = { version = "=2.0.8", features = ["full", "visit", "extra-traits"] }
+syn = { version = "2.0.8", features = ["full", "visit", "extra-traits"] }
 ignore = "0.4.17"
 uuid = { version = "1.0.0", features = ["v4"] }
 tempfile = "3.5.0"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true }
-clap = {version = "=4.1", features = ["derive", "env"]}
+clap = {version = "4.1", features = ["derive", "env"]}
 
 
 [dev-dependencies]

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -48,7 +48,7 @@ yaml = ["serde"]
 _cargo_insta_internal = ["clap"]
 
 [dependencies]
-dep_csv = { package = "csv", version = "=1.1.6", optional = true }
+dep_csv = { package = "csv", version = "1.1.6", optional = true }
 console = { version = "0.15.4", optional = true, default-features = false }
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
@@ -63,7 +63,7 @@ linked-hash-map = "0.5.6"
 lazy_static = "1.4.0"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }
-clap = {version = "=4.1", features = ["derive", "env"], optional = true}
+clap = {version = "4.1", features = ["derive", "env"], optional = true}
 
 [dev-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
Prepping for release -- these are locked in `Cargo.lock`. Locking them in `Cargo.toml`s could cause a conflict if used as a dependency in combination with other libraries which require a more recent version. This is more of a risk for `insta` rather than `cargo-insta`.

(I'm actually looking forward to the MSRV resolver!)
