### PR TITLE
Collapse empty methods

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -572,7 +572,7 @@ fn process_snapshots(
 
 fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>> {
     let loc = handle_target_args(&cmd.target_args, &cmd.test_runner_options.package)?;
-    match loc.tool_config.snapshot_update() {
+    match loc.tool_config.snapshot_update {
         SnapshotUpdate::Auto => {
             if is_ci() {
                 cmd.check = true;

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -361,8 +361,8 @@ struct LocationInfo<'a> {
 
 fn get_find_flags(tool_config: &ToolConfig, target_args: &TargetArgs) -> FindFlags {
     FindFlags {
-        include_ignored: target_args.include_ignored || tool_config.review_include_ignored(),
-        include_hidden: target_args.include_hidden || tool_config.review_include_hidden(),
+        include_ignored: target_args.include_ignored || tool_config.review_include_ignored,
+        include_hidden: target_args.include_hidden || tool_config.review_include_hidden,
     }
 }
 
@@ -476,7 +476,7 @@ fn process_snapshots(
     if snapshot_count == 0 {
         if !quiet {
             println!("{}: no snapshots to review", style("done").bold());
-            if loc.tool_config.review_warn_undiscovered() {
+            if loc.tool_config.review_warn_undiscovered {
                 show_undiscovered_hint(loc.find_flags, &snapshot_containers, &roots, &loc.exts);
             }
         }
@@ -602,10 +602,10 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
 
     // the tool config can also indicate that --accept-unseen should be picked
     // automatically unless instructed otherwise.
-    if loc.tool_config.auto_accept_unseen() && !cmd.accept && !cmd.review {
+    if loc.tool_config.auto_accept_unseen && !cmd.accept && !cmd.review {
         cmd.accept_unseen = true;
     }
-    if loc.tool_config.auto_review() && !cmd.review && !cmd.accept {
+    if loc.tool_config.auto_review && !cmd.review && !cmd.accept {
         cmd.review = true;
     }
 
@@ -617,14 +617,14 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
 
     // Prioritize the command line over the tool config
     let test_runner = match cmd.test_runner {
-        TestRunner::Auto => loc.tool_config.test_runner(),
+        TestRunner::Auto => loc.tool_config.test_runner,
         TestRunner::CargoTest => TestRunner::CargoTest,
         TestRunner::Nextest => TestRunner::Nextest,
     };
     // Prioritize the command line over the tool config
     let test_runner_fallback = cmd
         .test_runner_fallback
-        .unwrap_or(loc.tool_config.test_runner_fallback());
+        .unwrap_or(loc.tool_config.test_runner_fallback);
 
     let (mut proc, snapshot_ref_file, prevents_doc_run) = prepare_test_runner(
         test_runner,
@@ -702,7 +702,7 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
             return Err(QuietExit(1).into());
         } else {
             println!("{}: no snapshots to review", style("info").bold());
-            if loc.tool_config.review_warn_undiscovered() {
+            if loc.tool_config.review_warn_undiscovered {
                 show_undiscovered_hint(loc.find_flags, &snapshot_containers, &roots, &loc.exts);
             }
         }

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -103,22 +103,24 @@ pub struct ToolConfig {
     snapshot_update: SnapshotUpdate,
     #[cfg(feature = "glob")]
     glob_fail_fast: bool,
+    /// Whether to fallback to `cargo test` if the test runner isn't available
     #[cfg(feature = "_cargo_insta_internal")]
-    test_runner_fallback: bool,
+    pub test_runner_fallback: bool,
+    /// The intended test runner
     #[cfg(feature = "_cargo_insta_internal")]
-    test_runner: TestRunner,
+    pub test_runner: TestRunner,
     #[cfg(feature = "_cargo_insta_internal")]
-    test_unreferenced: UnreferencedSnapshots,
+    pub test_unreferenced: UnreferencedSnapshots,
     #[cfg(feature = "_cargo_insta_internal")]
-    auto_review: bool,
+    pub auto_review: bool,
     #[cfg(feature = "_cargo_insta_internal")]
-    auto_accept_unseen: bool,
+    pub auto_accept_unseen: bool,
     #[cfg(feature = "_cargo_insta_internal")]
-    review_include_ignored: bool,
+    pub review_include_ignored: bool,
     #[cfg(feature = "_cargo_insta_internal")]
-    review_include_hidden: bool,
+    pub review_include_hidden: bool,
     #[cfg(feature = "_cargo_insta_internal")]
-    review_warn_undiscovered: bool,
+    pub review_warn_undiscovered: bool,
 }
 
 impl ToolConfig {
@@ -307,45 +309,6 @@ impl ToolConfig {
     #[cfg(feature = "glob")]
     pub fn glob_fail_fast(&self) -> bool {
         self.glob_fail_fast
-    }
-}
-
-#[cfg(feature = "_cargo_insta_internal")]
-impl ToolConfig {
-    /// Returns the intended test runner
-    pub fn test_runner(&self) -> TestRunner {
-        self.test_runner
-    }
-
-    /// Whether to fallback to `cargo test` if the test runner isn't available
-    pub fn test_runner_fallback(&self) -> bool {
-        self.test_runner_fallback
-    }
-
-    pub fn test_unreferenced(&self) -> UnreferencedSnapshots {
-        self.test_unreferenced
-    }
-
-    /// Returns the auto review flag.
-    pub fn auto_review(&self) -> bool {
-        self.auto_review
-    }
-
-    /// Returns the auto accept unseen flag.
-    pub fn auto_accept_unseen(&self) -> bool {
-        self.auto_accept_unseen
-    }
-
-    pub fn review_include_hidden(&self) -> bool {
-        self.review_include_hidden
-    }
-
-    pub fn review_include_ignored(&self) -> bool {
-        self.review_include_ignored
-    }
-
-    pub fn review_warn_undiscovered(&self) -> bool {
-        self.review_warn_undiscovered
     }
 }
 

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -96,13 +96,13 @@ impl std::error::Error for Error {
 /// Represents a tool configuration.
 #[derive(Debug)]
 pub struct ToolConfig {
-    force_update_snapshots: bool,
-    force_pass: bool,
-    require_full_match: bool,
-    output: OutputBehavior,
-    snapshot_update: SnapshotUpdate,
+    pub force_update_snapshots: bool,
+    pub force_pass: bool,
+    pub require_full_match: bool,
+    pub output_behavior: OutputBehavior,
+    pub snapshot_update: SnapshotUpdate,
     #[cfg(feature = "glob")]
-    glob_fail_fast: bool,
+    pub glob_fail_fast: bool,
     /// Whether to fallback to `cargo test` if the test runner isn't available
     #[cfg(feature = "_cargo_insta_internal")]
     pub test_runner_fallback: bool,
@@ -184,7 +184,7 @@ impl ToolConfig {
                 Ok("1") => true,
                 _ => return Err(Error::Env("INSTA_FORCE_PASS")),
             },
-            output: {
+            output_behavior: {
                 let env_var = env::var("INSTA_OUTPUT");
                 let val = match env_var.as_deref() {
                     Err(_) | Ok("") => resolve(&cfg, &["behavior", "output"])
@@ -277,39 +277,6 @@ impl ToolConfig {
                 .unwrap_or(true),
         })
     }
-
-    // TODO: Do we want all these methods, vs. just allowing access to the fields?
-
-    /// Is insta told to force update snapshots?
-    pub fn force_update_snapshots(&self) -> bool {
-        self.force_update_snapshots
-    }
-
-    /// Should we fail if metadata doesn't match?
-    pub fn require_full_match(&self) -> bool {
-        self.require_full_match
-    }
-
-    /// Is insta instructed to fail in tests?
-    pub fn force_pass(&self) -> bool {
-        self.force_pass
-    }
-
-    /// Returns the intended output behavior for insta.
-    pub fn output_behavior(&self) -> OutputBehavior {
-        self.output
-    }
-
-    /// Returns the intended snapshot update behavior.
-    pub fn snapshot_update(&self) -> SnapshotUpdate {
-        self.snapshot_update
-    }
-
-    /// Returns the value of glob_fail_fast
-    #[cfg(feature = "glob")]
-    pub fn glob_fail_fast(&self) -> bool {
-        self.glob_fail_fast
-    }
 }
 
 /// How snapshots are supposed to be updated
@@ -325,7 +292,7 @@ pub enum SnapshotUpdateBehavior {
 
 /// Returns the intended snapshot update behavior.
 pub fn snapshot_update_behavior(tool_config: &ToolConfig, unseen: bool) -> SnapshotUpdateBehavior {
-    match tool_config.snapshot_update() {
+    match tool_config.snapshot_update {
         SnapshotUpdate::Always => SnapshotUpdateBehavior::InPlace,
         SnapshotUpdate::Auto => {
             if is_ci() {

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -61,7 +61,7 @@ pub fn glob_exec<F: FnMut(&Path)>(manifest_dir: &str, base: &Path, pattern: &str
     GLOB_STACK.lock().unwrap().push(GlobCollector {
         failed: 0,
         show_insta_hint: false,
-        fail_fast: get_tool_config(manifest_dir).glob_fail_fast(),
+        fail_fast: get_tool_config(manifest_dir).glob_fail_fast,
     });
 
     // step 1: collect all matching files

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -365,7 +365,7 @@ impl<'a> SnapshotAssertionContext<'a> {
             .snapshot_file
             .as_ref()
             .map_or(false, |x| fs::metadata(x).is_ok());
-        let should_print = self.tool_config.output_behavior() != OutputBehavior::Nothing;
+        let should_print = self.tool_config.output_behavior != OutputBehavior::Nothing;
         let snapshot_update = snapshot_update_behavior(&self.tool_config, unseen);
 
         match snapshot_update {
@@ -468,7 +468,7 @@ fn print_snapshot_info(ctx: &SnapshotAssertionContext, new_snapshot: &Snapshot) 
     printer.set_snapshot_file(ctx.snapshot_file.as_deref());
     printer.set_title(Some("Snapshot Summary"));
     printer.set_show_info(true);
-    match ctx.tool_config.output_behavior() {
+    match ctx.tool_config.output_behavior {
         OutputBehavior::Summary => {
             printer.print();
         }
@@ -513,7 +513,7 @@ fn finalize_assertion(ctx: &SnapshotAssertionContext, update_result: SnapshotUpd
 
     if fail_fast
         && update_result == SnapshotUpdateBehavior::NewFile
-        && ctx.tool_config.output_behavior() != OutputBehavior::Nothing
+        && ctx.tool_config.output_behavior != OutputBehavior::Nothing
         && !ctx.is_doctest
     {
         println!(
@@ -522,8 +522,8 @@ fn finalize_assertion(ctx: &SnapshotAssertionContext, update_result: SnapshotUpd
         );
     }
 
-    if update_result != SnapshotUpdateBehavior::InPlace && !ctx.tool_config.force_pass() {
-        if fail_fast && ctx.tool_config.output_behavior() != OutputBehavior::Nothing {
+    if update_result != SnapshotUpdateBehavior::InPlace && !ctx.tool_config.force_pass {
+        if fail_fast && ctx.tool_config.output_behavior != OutputBehavior::Nothing {
             let msg = if env::var("INSTA_CARGO_INSTA") == Ok("1".to_string()) {
                 "Stopped on the first failure."
             } else {
@@ -541,7 +541,7 @@ fn finalize_assertion(ctx: &SnapshotAssertionContext, update_result: SnapshotUpd
             if let Some(glob_collector) = stack.last_mut() {
                 glob_collector.failed += 1;
                 if update_result == SnapshotUpdateBehavior::NewFile
-                    && ctx.tool_config.output_behavior() != OutputBehavior::Nothing
+                    && ctx.tool_config.output_behavior != OutputBehavior::Nothing
                 {
                     glob_collector.show_insta_hint = true;
                 }
@@ -579,7 +579,7 @@ fn record_snapshot_duplicate(
             printer.set_snapshot_file(ctx.snapshot_file.as_deref());
             printer.set_title(Some("Differences in Block"));
             printer.set_snapshot_hints("previous assertion", "current assertion");
-            if ctx.tool_config.output_behavior() == OutputBehavior::Diff {
+            if ctx.tool_config.output_behavior == OutputBehavior::Diff {
                 printer.set_show_diff(true);
             }
             printer.print();
@@ -667,7 +667,7 @@ pub fn assert_snapshot(
         .old_snapshot
         .as_ref()
         .map(|x| {
-            if tool_config.require_full_match() {
+            if tool_config.require_full_match {
                 x.matches_fully(&new_snapshot)
             } else {
                 x.matches(&new_snapshot)
@@ -678,7 +678,7 @@ pub fn assert_snapshot(
     if pass {
         ctx.cleanup_passing()?;
 
-        if tool_config.force_update_snapshots() {
+        if tool_config.force_update_snapshots {
             ctx.update_snapshot(new_snapshot)?;
         }
     // otherwise print information and update snapshots.


### PR DESCRIPTION
Was there a reason to have all of these rather than just using the fields?
