### PR TITLE
Enable inline snapshots to be force-updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to insta and cargo-insta are documented here.
   themselves contain `###`. If there are no existing `#` characters in the
   snapshot value, a single `#` will be used.  #540
 
+- Inline snapshots can now be updated with `--force-update-snapshots`.  #569
+
 - `cargo insta test` accepts multiple `--exclude` flags.  #520
 
 - `test` `runner` in insta's yaml config works.  #544

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -71,7 +71,7 @@ fn assert_success(output: &std::process::Output) {
     // we would otherwise lose any output from the command such as `dbg!`
     // statements.
     eprint!("{}", String::from_utf8_lossy(&output.stderr));
-    // eprint!("{}", String::from_utf8_lossy(&output.stdout));
+    eprint!("{}", String::from_utf8_lossy(&output.stdout));
     assert!(
         output.status.success(),
         "Tests failed: {}\n{}",
@@ -724,15 +724,12 @@ fn test_force_update_inline_snapshot() {
             "Cargo.toml",
             r#"
 [package]
-name = "inline-force-update"
+name = "force-update-inline"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-doctest = false
-
 [dependencies]
-insta = { path = "$PROJECT_PATH" }
+insta = { path = '$PROJECT_PATH' }
 "#
             .to_string(),
         )

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -71,7 +71,7 @@ fn assert_success(output: &std::process::Output) {
     // we would otherwise lose any output from the command such as `dbg!`
     // statements.
     eprint!("{}", String::from_utf8_lossy(&output.stderr));
-    eprint!("{}", String::from_utf8_lossy(&output.stdout));
+    // eprint!("{}", String::from_utf8_lossy(&output.stdout));
     assert!(
         output.status.success(),
         "Tests failed: {}\n{}",

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -763,7 +763,6 @@ fn test_excessive_hashes() {
 
     assert_success(&output);
 
-    // Check the contents of the updated file
     assert_snapshot!(test_project.diff("src/lib.rs"), @r#####"
     --- Original: src/lib.rs
     +++ Updated: src/lib.rs

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -71,6 +71,7 @@ fn assert_success(output: &std::process::Output) {
     // we would otherwise lose any output from the command such as `dbg!`
     // statements.
     eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    eprint!("{}", String::from_utf8_lossy(&output.stdout));
     assert!(
         output.status.success(),
         "Tests failed: {}\n{}",
@@ -714,4 +715,64 @@ fn test_virtual_manifest_single_crate() {
          member-2/Cargo.toml
          member-2/src
     "###     );
+}
+
+#[test]
+fn test_force_update_inline_snapshot() {
+    let test_project = TestFiles::new()
+        .add_file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "inline-force-update"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+doctest = false
+
+[dependencies]
+insta = { path = "$PROJECT_PATH" }
+"#
+            .to_string(),
+        )
+        .add_file(
+            "src/lib.rs",
+            r#####"
+#[test]
+fn test_excessive_hashes() {
+    insta::assert_snapshot!("foo", @r####"foo"####);
+}
+"#####
+                .to_string(),
+        )
+        .create_project();
+
+    // Run the test with --force-update-snapshots and --accept
+    let output = test_project
+        .cmd()
+        .args([
+            "test",
+            "--force-update-snapshots",
+            "--accept",
+            "--",
+            "--nocapture",
+        ])
+        .output()
+        .unwrap();
+
+    assert_success(&output);
+
+    // Check the contents of the updated file
+    assert_snapshot!(test_project.diff("src/lib.rs"), @r#####"
+    --- Original: src/lib.rs
+    +++ Updated: src/lib.rs
+    @@ -1,5 +1,5 @@
+     
+     #[test]
+     fn test_excessive_hashes() {
+    -    insta::assert_snapshot!("foo", @r####"foo"####);
+    +    insta::assert_snapshot!("foo", @"foo");
+     }
+    "#####);
 }

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -397,6 +397,7 @@ impl<'a> SnapshotAssertionContext<'a> {
             }
             SnapshotUpdateBehavior::NewFile => {
                 if let Some(ref snapshot_file) = self.snapshot_file {
+                    // File snapshot
                     if let Some(new_path) = new_snapshot.save_new(snapshot_file)? {
                         if should_print {
                             elog!(
@@ -415,19 +416,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                                 .bold(),
                         );
                     }
-
-                // special case for pending inline snapshots.  Here we really only want
-                // to write the contents if the snapshot contents changed as the metadata
-                // is not retained for inline snapshots.  This used to have different
-                // behavior in the past where we did indeed want to rewrite the snapshots
-                // entirely since we used to change the canonical snapshot format, but now
-                // this is significantly less likely to happen and seeing hundreds of unchanged
-                // inline snapshots in the review screen is not a lot of fun.
-                } else if self
-                    .old_snapshot
-                    .as_ref()
-                    .map_or(true, |x| x.contents() != new_snapshot.contents())
-                {
+                } else {
                     PendingInlineSnapshot::new(
                         Some(new_snapshot),
                         self.old_snapshot.clone(),


### PR DESCRIPTION
We previously excluded these. But it's somewhat required for #563, and I don't think there's a big downside -- we only generate pending files when a snapshot doesn't match of `--force-update-snapshots` is passed.
