### PR TITLE
Generalise filters to support `IntoIterator` types, not just `Vec`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to insta and cargo-insta are documented here.
 
 - Add a new integration test approach for `cargo-insta` and a set of integration tests.  #537
 
+- Enable Filters to be created from `IntoIterator` types, rather than just `Vec`s.  #570
+
 ## 1.39.0
 
 - Fixed a bug in `require_full_match`.  #485

--- a/insta/src/filters.rs
+++ b/insta/src/filters.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::iter::FromIterator;
+use std::iter::IntoIterator;
 
 use regex::Regex;
 
@@ -10,9 +11,12 @@ pub struct Filters {
     rules: Vec<(Regex, String)>,
 }
 
-impl<'a> From<Vec<(&'a str, &'a str)>> for Filters {
-    fn from(value: Vec<(&'a str, &'a str)>) -> Self {
-        Self::from_iter(value)
+impl<'a, I> From<I> for Filters
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    fn from(value: I) -> Self {
+        Self::from_iter(value.into_iter())
     }
 }
 


### PR DESCRIPTION
Currently filters must be `Vec`s:

```rust
insta::with_settings!({filters => vec![
    (r"tmp\/\.tmp.*\/", "[TEMPDIR]"),
    (r"var\/.*\/\.tmp.*\/", "[TEMPDIR]"),
]}, { }
```

However, using an array could be cleaner:

```rust
insta::with_settings!({filters => [
    (r"tmp\/\.tmp.*\/", "[TEMPDIR]"),
    (r"var\/.*\/\.tmp.*\/", "[TEMPDIR]"),
]}, { }
```

And finally, it enables the filters to be extracted into a `const`:

```rust
const FILTERS: [(&'static str, &'static str); 2] = [
    (r"tmp\/\.tmp.*\/", "[TEMPDIR]"),
    (r"var\/.*\/\.tmp.*\/", "[TEMPDIR]"),
];
insta::with_settings!({filters => FILTERS}, { }
```