### PR TITLE
Adjust force-update on inline snapshots to only view within the string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## 1.41.0
 
+- `--force-update-snapshots` has more conservative and consistent behavior for
+  inline snapshots. As a side-effect of this, only the content within the inline
+  snapshot delimiters are assessed for changes, not the delimiters (e.g. `###`).
+  #581
+
 ## 1.40.0
 
 - `cargo-insta` no longer panics when running `cargo insta test --accept --workspace`

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -1061,8 +1061,8 @@ fn pending_snapshots_cmd(cmd: PendingSnapshotsCommand) -> Result<(), Box<dyn Err
         let is_inline = snapshot_container.snapshot_file().is_none();
         for snapshot_ref in snapshot_container.iter_snapshots() {
             if cmd.as_json {
-                let old_snapshot = snapshot_ref.old.as_ref().map(|x| x.contents_str());
-                let new_snapshot = snapshot_ref.new.contents_str();
+                let old_snapshot = snapshot_ref.old.as_ref().map(|x| x.contents_string());
+                let new_snapshot = snapshot_ref.new.contents_string();
                 let info = if is_inline {
                     SnapshotKey::InlineSnapshot {
                         path: &target_file,

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -1061,12 +1061,14 @@ fn pending_snapshots_cmd(cmd: PendingSnapshotsCommand) -> Result<(), Box<dyn Err
         let is_inline = snapshot_container.snapshot_file().is_none();
         for snapshot_ref in snapshot_container.iter_snapshots() {
             if cmd.as_json {
+                let old_snapshot = snapshot_ref.old.as_ref().map(|x| x.contents_str());
+                let new_snapshot = snapshot_ref.new.contents_str();
                 let info = if is_inline {
                     SnapshotKey::InlineSnapshot {
                         path: &target_file,
                         line: snapshot_ref.line.unwrap(),
-                        old_snapshot: snapshot_ref.old.as_ref().map(|x| x.contents_str()),
-                        new_snapshot: snapshot_ref.new.contents_str(),
+                        old_snapshot: old_snapshot.as_deref(),
+                        new_snapshot: &new_snapshot,
                         expression: snapshot_ref.new.metadata().expression(),
                     }
                 } else {

--- a/cargo-insta/src/container.rs
+++ b/cargo-insta/src/container.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use insta::Snapshot;
+pub(crate) use insta::SnapshotKind;
 use insta::_cargo_insta_support::{ContentError, PendingInlineSnapshot};
 
 use crate::inline::FilePatcher;
@@ -12,12 +13,6 @@ pub(crate) enum Operation {
     Accept,
     Reject,
     Skip,
-}
-
-#[derive(Debug)]
-pub(crate) enum SnapshotContainerKind {
-    Inline,
-    External,
 }
 
 #[derive(Debug)]
@@ -51,7 +46,7 @@ impl PendingSnapshot {
 pub(crate) struct SnapshotContainer {
     snapshot_path: PathBuf,
     target_path: PathBuf,
-    kind: SnapshotContainerKind,
+    kind: SnapshotKind,
     snapshots: Vec<PendingSnapshot>,
     patcher: Option<FilePatcher>,
 }
@@ -60,11 +55,11 @@ impl SnapshotContainer {
     pub(crate) fn load(
         snapshot_path: PathBuf,
         target_path: PathBuf,
-        kind: SnapshotContainerKind,
+        kind: SnapshotKind,
     ) -> Result<SnapshotContainer, Box<dyn Error>> {
         let mut snapshots = Vec::new();
         let patcher = match kind {
-            SnapshotContainerKind::External => {
+            SnapshotKind::File => {
                 let old = if fs::metadata(&target_path).is_err() {
                     None
                 } else {
@@ -80,7 +75,7 @@ impl SnapshotContainer {
                 });
                 None
             }
-            SnapshotContainerKind::Inline => {
+            SnapshotKind::Inline => {
                 let mut pending_vec = PendingInlineSnapshot::load_batch(&snapshot_path)?;
                 let mut have_new = false;
 
@@ -136,8 +131,8 @@ impl SnapshotContainer {
 
     pub(crate) fn snapshot_file(&self) -> Option<&Path> {
         match self.kind {
-            SnapshotContainerKind::External => Some(&self.target_path),
-            SnapshotContainerKind::Inline => None,
+            SnapshotKind::File => Some(&self.target_path),
+            SnapshotKind::Inline => None,
         }
     }
 

--- a/cargo-insta/src/walk.rs
+++ b/cargo-insta/src/walk.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use ignore::overrides::OverrideBuilder;
 use ignore::{DirEntry, Walk, WalkBuilder};
 
-use crate::container::{SnapshotContainer, SnapshotContainerKind};
+use crate::container::{SnapshotContainer, SnapshotKind};
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct FindFlags {
@@ -37,7 +37,7 @@ pub(crate) fn find_snapshots<'a>(
                 Some(SnapshotContainer::load(
                     new_path,
                     old_path,
-                    SnapshotContainerKind::External,
+                    SnapshotKind::File,
                 ))
             } else if fname.starts_with('.') && fname.ends_with(".pending-snap") {
                 let mut target_path = e.path().to_path_buf();
@@ -45,7 +45,7 @@ pub(crate) fn find_snapshots<'a>(
                 Some(SnapshotContainer::load(
                     e.path().to_path_buf(),
                     target_path,
-                    SnapshotContainerKind::Inline,
+                    SnapshotKind::Inline,
                 ))
             } else {
                 None

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -12,7 +12,8 @@
 /// temporary workspace dirs. (We could try to enforce different names, or give
 /// up using a consistent target directory for a cache, but it would slow down
 /// repeatedly running the tests locally. To demonstrate the effect, name crates
-/// the same...)
+/// the same...). This also causes issues when running the same tests
+/// concurrently.
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -724,6 +725,115 @@ fn test_virtual_manifest_single_crate() {
          member-2/Cargo.toml
          member-2/src
     "###     );
+}
+
+#[test]
+fn test_force_update_snapshots() {
+    // We test with both 1.39 and `master`. These currently test the same code!
+    // But I copied the test from
+    // https://github.com/mitsuhiko/insta/pull/482/files where they'll test
+    // different code. If we don't end up merging that, we can remove one of the
+    // tests (but didn't think it was worthwhile to do the work to then undo it)
+
+    fn create_test_force_update_project(name: &str, insta_dependency: &str) -> TestProject {
+        TestFiles::new()
+            .add_file(
+                "Cargo.toml",
+                format!(
+                    r#"
+[package]
+name = "test_force_update_{}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+insta = {}
+"#,
+                    name, insta_dependency
+                )
+                .to_string(),
+            )
+            .add_file(
+                "src/lib.rs",
+                r#"
+#[test]
+fn test_snapshot_with_newline() {
+    insta::assert_snapshot!("force_update", "Hello, world!");
+}
+"#
+                .to_string(),
+            )
+            .add_file(
+                format!(
+                    "src/snapshots/test_force_update_{}__force_update.snap",
+                    name
+                ),
+                r#"
+---
+source: src/lib.rs
+expression: 
+---
+Hello, world!
+
+
+"#
+                .to_string(),
+            )
+            .create_project()
+    }
+
+    let test_current_insta =
+        create_test_force_update_project("current", "{ path = '$PROJECT_PATH' }");
+    let test_insta_1_39_0 = create_test_force_update_project("1_39_0", "\"1.39.0\"");
+
+    // Test with current insta version
+    let output_current = test_current_insta
+        .cmd()
+        .args(["test", "--accept", "--force-update-snapshots"])
+        .output()
+        .unwrap();
+
+    assert_success(&output_current);
+
+    // Test with insta 1.39.0
+    let output_1_39_0 = test_insta_1_39_0
+        .cmd()
+        .args(["test", "--accept", "--force-update-snapshots"])
+        .output()
+        .unwrap();
+
+    assert_success(&output_1_39_0);
+
+    // Check that both versions updated the snapshot correctly
+    assert_snapshot!(test_current_insta.diff("src/snapshots/test_force_update_current__force_update.snap"), @r#"
+    --- Original: src/snapshots/test_force_update_current__force_update.snap
+    +++ Updated: src/snapshots/test_force_update_current__force_update.snap
+    @@ -1,8 +1,5 @@
+    -
+     ---
+     source: src/lib.rs
+    -expression: 
+    +expression: "\"Hello, world!\""
+     ---
+     Hello, world!
+    -
+    -
+    "#);
+
+    assert_snapshot!(test_insta_1_39_0.diff("src/snapshots/test_force_update_1_39_0__force_update.snap"), @r#"
+    --- Original: src/snapshots/test_force_update_1_39_0__force_update.snap
+    +++ Updated: src/snapshots/test_force_update_1_39_0__force_update.snap
+    @@ -1,8 +1,5 @@
+    -
+     ---
+     source: src/lib.rs
+    -expression: 
+    +expression: "\"Hello, world!\""
+     ---
+     Hello, world!
+    -
+    -
+    "#);
 }
 
 #[test]

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1009,16 +1009,14 @@ fn test_wrong_indent_force() {
     assert_snapshot!(test_project.diff("src/lib.rs"), @r##"
     --- Original: src/lib.rs
     +++ Updated: src/lib.rs
-    @@ -5,7 +5,9 @@
+    @@ -5,7 +5,7 @@
          foo
          foo
          "#, @r#"
     -                foo
     -                foo
-    +
-    +        foo
-    +        foo
-    +        
+    +    foo
+    +    foo
          "#);
      }
     "##);
@@ -1045,7 +1043,7 @@ insta = { path = '$PROJECT_PATH' }
             r#"
 #[test]
 fn test_hashtag_escape() {
-    insta::assert_snapshot!("Value with #### hashtags\n", @"");
+    insta::assert_snapshot!("Value with\n#### hashtags\n", @"");
 }
 "#
             .to_string(),
@@ -1063,13 +1061,14 @@ fn test_hashtag_escape() {
     assert_snapshot!(test_project.diff("src/main.rs"), @r######"
     --- Original: src/main.rs
     +++ Updated: src/main.rs
-    @@ -1,5 +1,7 @@
+    @@ -1,5 +1,8 @@
      
      #[test]
      fn test_hashtag_escape() {
-    -    insta::assert_snapshot!("Value with #### hashtags\n", @"");
-    +    insta::assert_snapshot!("Value with #### hashtags\n", @r#####"
-    +    Value with #### hashtags
+    -    insta::assert_snapshot!("Value with\n#### hashtags\n", @"");
+    +    insta::assert_snapshot!("Value with\n#### hashtags\n", @r#####"
+    +    Value with
+    +    #### hashtags
     +    "#####);
      }
     "######);

--- a/insta/src/lib.rs
+++ b/insta/src/lib.rs
@@ -288,7 +288,7 @@ mod glob;
 mod test;
 
 pub use crate::settings::Settings;
-pub use crate::snapshot::{MetaData, Snapshot};
+pub use crate::snapshot::{MetaData, Snapshot, SnapshotKind};
 
 /// Exposes some library internals.
 ///

--- a/insta/src/output.rs
+++ b/insta/src/output.rs
@@ -103,7 +103,7 @@ impl<'a> SnapshotPrinter<'a> {
     fn print_snapshot(&self) {
         print_line(term_width());
 
-        let new_contents = self.new_snapshot.contents_str();
+        let new_contents = self.new_snapshot.contents_string();
 
         let width = term_width();
         if self.show_info {
@@ -120,8 +120,8 @@ impl<'a> SnapshotPrinter<'a> {
     fn print_changeset(&self) {
         let old: String = self
             .old_snapshot
-            .map_or("".to_string(), |x| x.contents_str());
-        let new = self.new_snapshot.contents_str();
+            .map_or("".to_string(), |x| x.contents_string());
+        let new = self.new_snapshot.contents_string();
         let newlines_matter = newlines_matter(old.as_str(), new.as_str());
 
         let width = term_width();

--- a/insta/src/output.rs
+++ b/insta/src/output.rs
@@ -118,15 +118,17 @@ impl<'a> SnapshotPrinter<'a> {
     }
 
     fn print_changeset(&self) {
-        let old = self.old_snapshot.as_ref().map_or("", |x| x.contents_str());
+        let old: String = self
+            .old_snapshot
+            .map_or("".to_string(), |x| x.contents_str());
         let new = self.new_snapshot.contents_str();
-        let newlines_matter = newlines_matter(old, new);
+        let newlines_matter = newlines_matter(old.as_str(), new.as_str());
 
         let width = term_width();
         let diff = TextDiff::configure()
             .algorithm(Algorithm::Patience)
             .timeout(Duration::from_millis(500))
-            .diff_lines(old, new);
+            .diff_lines(old.as_str(), new.as_str());
         print_line(width);
 
         if self.show_info {

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -290,8 +290,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                     module_path.replace("::", "__"),
                     None,
                     MetaData::default(),
-                    SnapshotKind::Inline,
-                    SnapshotContents::from_inline(contents),
+                    SnapshotContents::new(contents.to_string(), SnapshotKind::Inline),
                 ));
             }
         };
@@ -319,12 +318,7 @@ impl<'a> SnapshotAssertionContext<'a> {
     }
 
     /// Creates the new snapshot from input values.
-    pub fn new_snapshot(
-        &self,
-        contents: SnapshotContents,
-        expr: &str,
-        kind: SnapshotKind,
-    ) -> Snapshot {
+    pub fn new_snapshot(&self, contents: SnapshotContents, expr: &str) -> Snapshot {
         Snapshot::from_components(
             self.module_path.replace("::", "__"),
             self.snapshot_name.as_ref().map(|x| x.to_string()),
@@ -343,7 +337,6 @@ impl<'a> SnapshotAssertionContext<'a> {
                     .and_then(|x| self.localize_path(x))
                     .map(|x| path_to_storage(&x)),
             }),
-            kind,
             contents,
         )
     }
@@ -651,7 +644,8 @@ pub fn assert_snapshot(
         Some(_) => SnapshotKind::File,
         None => SnapshotKind::Inline,
     };
-    let new_snapshot = ctx.new_snapshot(new_snapshot_value.into(), expr, kind);
+    let new_snapshot =
+        ctx.new_snapshot(SnapshotContents::new(new_snapshot_value.into(), kind), expr);
 
     // memoize the snapshot file if requested.
     if let Some(ref snapshot_file) = ctx.snapshot_file {

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -683,7 +683,10 @@ pub fn assert_snapshot(
     if pass {
         ctx.cleanup_passing()?;
 
-        if tool_config.force_update_snapshots() {
+        if matches!(
+            tool_config.snapshot_update(),
+            crate::env::SnapshotUpdate::Force
+        ) {
             // Avoid creating new files if contents match exactly. In
             // particular, this would otherwise create lots of unneeded files
             // for inline snapshots

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -448,14 +448,16 @@ impl Snapshot {
         self.snapshot.kind
     }
 
-    /// Both exact snapshot contents and metadata matches another snapshot's.
+    /// Both the exact snapshot contents and the persisted metadata match another snapshot's.
     pub fn matches_fully(&self, other: &Snapshot) -> bool {
         match self.kind() {
             SnapshotKind::File => {
                 self.metadata.trim_for_persistence() == other.metadata.trim_for_persistence()
                     && self.contents().as_str_exact() == other.contents().as_str_exact()
             }
-            SnapshotKind::Inline => self.contents().to_inline(0) == other.contents().to_inline(0),
+            SnapshotKind::Inline => {
+                self.contents().as_str_exact() == other.contents().as_str_exact()
+            }
         }
     }
 

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -553,7 +553,7 @@ impl SnapshotContents {
     /// Returns the string literal, including `#` delimiters, to insert into a
     /// Rust source file.
     pub fn to_inline(&self, indentation: usize) -> String {
-        let contents = &self.contents;
+        let contents = self.normalize();
         let mut out = String::new();
 
         // We don't technically need to escape on newlines, but it reduces diffs
@@ -595,7 +595,7 @@ impl SnapshotContents {
                     .chain(Some(format!("\n{:width$}", "", width = indentation))),
             );
         } else {
-            out.push_str(contents);
+            out.push_str(contents.as_str());
         }
 
         out.push('"');
@@ -796,8 +796,8 @@ b
     assert_eq!(
         SnapshotContents::new("\n    a\n    b".to_string(), SnapshotKind::Inline).to_inline(0),
         r##"r#"
-    a
-    b
+a
+b
 "#"##
     );
 
@@ -812,9 +812,7 @@ b
 
     assert_eq!(
         SnapshotContents::new("\n    ab\n".to_string(), SnapshotKind::Inline).to_inline(0),
-        r##"r#"
-    ab
-"#"##
+        r##""ab""##
     );
 
     assert_eq!(

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -449,27 +449,29 @@ impl Snapshot {
     }
 
     /// Both the exact snapshot contents and the persisted metadata match another snapshot's.
+    // (could rename to `matches_exact` for consistency, after some current
+    // pending merge requests are merged)
     pub fn matches_fully(&self, other: &Snapshot) -> bool {
+        let contents_match_exact =
+            self.contents().as_str_exact() == other.contents().as_str_exact();
         match self.kind() {
             SnapshotKind::File => {
                 self.metadata.trim_for_persistence() == other.metadata.trim_for_persistence()
-                    && self.contents().as_str_exact() == other.contents().as_str_exact()
+                    && contents_match_exact
             }
-            SnapshotKind::Inline => {
-                self.contents().as_str_exact() == other.contents().as_str_exact()
-            }
+            SnapshotKind::Inline => contents_match_exact,
         }
     }
 
-    /// The snapshot contents as a String
-    pub fn contents_str(&self) -> String {
+    /// The normalized snapshot contents as a String
+    pub fn contents_string(&self) -> String {
         self.snapshot.to_string()
     }
 
     fn serialize_snapshot(&self, md: &MetaData) -> String {
         let mut buf = yaml::to_string(&md.as_content());
         buf.push_str("---\n");
-        buf.push_str(self.contents_str().as_str());
+        buf.push_str(self.contents_string().as_str());
         buf.push('\n');
         buf
     }
@@ -544,6 +546,10 @@ pub struct SnapshotContents {
 
 impl SnapshotContents {
     pub fn new(contents: String, kind: SnapshotKind) -> SnapshotContents {
+        // We could store a normalized version of the string as part of `new`;
+        // it would avoid allocating a new `String` when we getting normalized
+        // versions, which we may do a few times. (We want to store the
+        // unnormalized version because it allows us to use `matches_fully`.)
         SnapshotContents { contents, kind }
     }
 

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -471,7 +471,7 @@ impl Snapshot {
 
     /// The normalized snapshot contents as a String
     pub fn contents_string(&self) -> String {
-        self.snapshot.to_string()
+        self.snapshot.normalize()
     }
 
     fn serialize_snapshot(&self, md: &MetaData) -> String {


### PR DESCRIPTION
This solves the issue in #573 for the moment:
- When `--force-update-snapshots` in passed, we only update inline snapshots when there's some difference _within_ the string, such as an additional linebreak at the start or the end
- We no longer update the surrounding hashes. In the existing code, this happened because we were writing too many inline snapshots, not because we were actually checking the number of hashes
  - Checking the number of hashes isn't easy to do — reason outlined at https://github.com/mitsuhiko/insta/pull/573#issuecomment-2323500808
- The main change in the code is that we store the unnormalized snapshot and then normalize when we need to. The existing code stored the normalized version, which meant we couldn't evaluate whether the unnormalized versions were different

It's a decent number of changes, but will integrate nicely with https://github.com/mitsuhiko/insta/pull/563.

~(FYI we currently don't look at the indentation, but we could adjust this)~ Now indentation works too