### PR TITLE
Consolidate onto `INSTA_WORKSPACE_ROOT`

### DIFF
--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1215,7 +1215,6 @@ fn test_insta_workspace_root() {
     #[cfg(test)]
     mod tests {
         use insta::assert_snapshot;
-        use super::*;
 
         #[test]
         fn test_snapshot() {

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 /// Integration tests which allow creating a full repo, running `cargo-insta`
 /// and then checking the output.
 ///
@@ -14,11 +17,8 @@
 /// repeatedly running the tests locally. To demonstrate the effect, name crates
 /// the same...). This also causes issues when running the same tests
 /// concurrently.
-use std::collections::HashMap;
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{collections::HashMap, os::unix::fs::PermissionsExt};
+use std::{env, fs::remove_dir_all};
 
 use ignore::WalkBuilder;
 use insta::assert_snapshot;
@@ -81,6 +81,16 @@ fn assert_success(output: &std::process::Output) {
     );
 }
 
+fn assert_failure(output: &std::process::Output) {
+    eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    eprint!("{}", String::from_utf8_lossy(&output.stdout));
+    assert!(
+        !output.status.success(),
+        "Tests unexpectedly succeeded: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
 struct TestProject {
     /// Temporary directory where the project is created
     workspace_dir: PathBuf,
@@ -110,23 +120,26 @@ impl TestProject {
             workspace_dir,
         }
     }
-    fn cmd(&self) -> Command {
-        let mut command = Command::new(env!("CARGO_BIN_EXE_cargo-insta"));
+    fn clean_env(cmd: &mut Command) {
         // Remove environment variables so we don't inherit anything (such as
         // `INSTA_FORCE_PASS` or `CARGO_INSTA_*`) from a cargo-insta process
         // which runs this integration test.
         for (key, _) in env::vars() {
             if key.starts_with("CARGO_INSTA") || key.starts_with("INSTA") {
-                command.env_remove(&key);
+                cmd.env_remove(&key);
             }
         }
         // Turn off CI flag so that cargo insta test behaves as we expect
         // under normal operation
-        command.env("CI", "0");
+        cmd.env("CI", "0");
         // And any others that can affect the output
-        command.env_remove("CARGO_TERM_COLOR");
-        command.env_remove("CLICOLOR_FORCE");
-        command.env_remove("RUSTDOCFLAGS");
+        cmd.env_remove("CARGO_TERM_COLOR");
+        cmd.env_remove("CLICOLOR_FORCE");
+        cmd.env_remove("RUSTDOCFLAGS");
+    }
+    fn cmd(&self) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_cargo-insta"));
+        Self::clean_env(&mut command);
 
         command.current_dir(self.workspace_dir.as_path());
         // Use the same target directory as other tests, consistent across test
@@ -1144,4 +1157,130 @@ fn test_hashtag_escape() {
     +    "###);
      }
     "####);
+}
+
+#[test]
+fn test_insta_workspace_root() {
+    // This function locates the compiled test binary in the target directory.
+    // It's necessary because the exact filename of the test binary includes a hash
+    // that we can't predict, so we need to search for it.
+    fn find_test_binary(dir: &Path) -> PathBuf {
+        dir.join("target/debug/deps")
+            .read_dir()
+            .unwrap()
+            .filter_map(Result::ok)
+            .find(|entry| {
+                let file_name = entry.file_name();
+                let file_name_str = file_name.to_str().unwrap_or("");
+                // We're looking for a file that:
+                file_name_str.starts_with("insta_workspace_root_test-") // Matches our test name
+                    && !file_name_str.contains('.') // Doesn't have an extension (it's the executable, not a metadata file)
+                    && entry.metadata().map(|m| m.is_file()).unwrap_or(false) // Is a file, not a directory
+                    && entry
+                        .metadata()
+                        .map(|m| m.permissions().mode() & 0o111 != 0)
+                        .unwrap_or(false) // Has executable permissions
+            })
+            .map(|entry| entry.path())
+            .expect("Failed to find test binary")
+    }
+
+    fn run_test_binary(
+        binary_path: &Path,
+        current_dir: &Path,
+        env: Option<(&str, &str)>,
+    ) -> std::process::Output {
+        let mut cmd = Command::new(binary_path);
+        TestProject::clean_env(&mut cmd);
+        cmd.current_dir(current_dir);
+        if let Some((key, value)) = env {
+            cmd.env(key, value);
+        }
+        cmd.output().unwrap()
+    }
+
+    let test_project = TestFiles::new()
+        .add_file(
+            "Cargo.toml",
+            r#"
+    [package]
+    name = "insta_workspace_root_test"
+    version = "0.1.0"
+    edition = "2021"
+
+    [dependencies]
+    insta = { path = '$PROJECT_PATH' }
+    "#
+            .to_string(),
+        )
+        .add_file(
+            "src/lib.rs",
+            r#"
+    use insta::assert_snapshot;
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_snapshot() {
+            assert_snapshot!("Hello, world!");
+        }
+    }
+    "#
+            .to_string(),
+        )
+        .create_project();
+
+    let mut cargo_cmd = Command::new("cargo");
+    TestProject::clean_env(&mut cargo_cmd);
+    let output = cargo_cmd
+        .args(["test", "--no-run"])
+        .current_dir(&test_project.workspace_dir)
+        .output()
+        .unwrap();
+    assert_success(&output);
+
+    let test_binary_path = find_test_binary(&test_project.workspace_dir);
+
+    // Run the test without snapshot (should fail)
+    assert_failure(&run_test_binary(
+        &test_binary_path,
+        &test_project.workspace_dir,
+        None,
+    ));
+
+    // Create the snapshot
+    assert_success(&run_test_binary(
+        &test_binary_path,
+        &test_project.workspace_dir,
+        Some(("INSTA_UPDATE", "always")),
+    ));
+
+    // Verify snapshot creation
+    assert!(test_project.workspace_dir.join("src/snapshots").exists());
+    assert!(test_project
+        .workspace_dir
+        .join("src/snapshots/insta_workspace_root_test__tests__snapshot.snap")
+        .exists());
+
+    // Move the workspace
+    let moved_workspace = {
+        let moved_workspace = PathBuf::from("/tmp/cargo-insta-test-moved");
+        remove_dir_all(&moved_workspace).ok();
+        fs::create_dir(&moved_workspace).unwrap();
+        fs::rename(&test_project.workspace_dir, &moved_workspace).unwrap();
+        moved_workspace
+    };
+    let moved_binary_path = find_test_binary(&moved_workspace);
+
+    // Run test in moved workspace without INSTA_WORKSPACE_ROOT (should fail)
+    assert_failure(&run_test_binary(&moved_binary_path, &moved_workspace, None));
+
+    // Run test in moved workspace with INSTA_WORKSPACE_ROOT (should pass)
+    assert_success(&run_test_binary(
+        &moved_binary_path,
+        &moved_workspace,
+        Some(("INSTA_WORKSPACE_ROOT", moved_workspace.to_str().unwrap())),
+    ));
 }

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1159,6 +1159,10 @@ fn test_hashtag_escape() {
     "####);
 }
 
+// Can't get the test binary discovery to work, don't have a windows machine to
+// hand, others are welcome to fix it. (No specific reason to think that insta
+// doesn't work on windows, just that the test doesn't work.)
+#[cfg(not(target_os = "windows"))]
 #[test]
 fn test_insta_workspace_root() {
     // This function locates the compiled test binary in the target directory.

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1,6 +1,3 @@
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
 /// Integration tests which allow creating a full repo, running `cargo-insta`
 /// and then checking the output.
 ///
@@ -17,7 +14,10 @@ use std::process::Command;
 /// repeatedly running the tests locally. To demonstrate the effect, name crates
 /// the same...). This also causes issues when running the same tests
 /// concurrently.
-use std::{collections::HashMap, os::unix::fs::PermissionsExt};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::{env, fs::remove_dir_all};
 
 use ignore::WalkBuilder;
@@ -1176,10 +1176,6 @@ fn test_insta_workspace_root() {
                 file_name_str.starts_with("insta_workspace_root_test-") // Matches our test name
                     && !file_name_str.contains('.') // Doesn't have an extension (it's the executable, not a metadata file)
                     && entry.metadata().map(|m| m.is_file()).unwrap_or(false) // Is a file, not a directory
-                    && entry
-                        .metadata()
-                        .map(|m| m.permissions().mode() & 0o111 != 0)
-                        .unwrap_or(false) // Has executable permissions
             })
             .map(|entry| entry.path())
             .expect("Failed to find test binary")

--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1212,10 +1212,9 @@ fn test_insta_workspace_root() {
         .add_file(
             "src/lib.rs",
             r#"
-    use insta::assert_snapshot;
-
     #[cfg(test)]
     mod tests {
+        use insta::assert_snapshot;
         use super::*;
 
         #[test]

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -12,15 +12,15 @@ use crate::{
 
 lazy_static::lazy_static! {
     static ref WORKSPACES: Mutex<BTreeMap<String, Arc<PathBuf>>> = Mutex::new(BTreeMap::new());
-    static ref TOOL_CONFIGS: Mutex<BTreeMap<String, Arc<ToolConfig>>> = Mutex::new(BTreeMap::new());
+    static ref TOOL_CONFIGS: Mutex<BTreeMap<PathBuf, Arc<ToolConfig>>> = Mutex::new(BTreeMap::new());
 }
 
-pub fn get_tool_config(manifest_dir: &str) -> Arc<ToolConfig> {
+pub fn get_tool_config(workspace_dir: &Path) -> Arc<ToolConfig> {
     TOOL_CONFIGS
         .lock()
         .unwrap()
-        .entry(manifest_dir.to_string())
-        .or_insert_with(|| ToolConfig::from_manifest_dir(manifest_dir).unwrap().into())
+        .entry(workspace_dir.to_path_buf())
+        .or_insert_with(|| ToolConfig::from_workspace(workspace_dir).unwrap().into())
         .clone()
 }
 
@@ -123,11 +123,6 @@ pub struct ToolConfig {
 }
 
 impl ToolConfig {
-    /// Loads the tool config for a specific manifest.
-    pub fn from_manifest_dir(manifest_dir: &str) -> Result<ToolConfig, Error> {
-        Self::from_workspace(&get_cargo_workspace(manifest_dir))
-    }
-
     /// Loads the tool config from a cargo workspace.
     pub fn from_workspace(workspace_dir: &Path) -> Result<ToolConfig, Error> {
         let mut cfg = None;

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -38,7 +38,7 @@ lazy_static::lazy_static! {
     };
 }
 
-pub fn glob_exec<F: FnMut(&Path)>(manifest_dir: &str, base: &Path, pattern: &str, mut f: F) {
+pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &str, mut f: F) {
     // If settings.allow_empty_glob() == true and `base` doesn't exist, skip
     // everything. This is necessary as `base` is user-controlled via `glob!/3`
     // and may not exist.
@@ -61,7 +61,7 @@ pub fn glob_exec<F: FnMut(&Path)>(manifest_dir: &str, base: &Path, pattern: &str
     GLOB_STACK.lock().unwrap().push(GlobCollector {
         failed: 0,
         show_insta_hint: false,
-        fail_fast: get_tool_config(manifest_dir).glob_fail_fast(),
+        fail_fast: get_tool_config(workspace_dir).glob_fail_fast(),
     });
 
     // step 1: collect all matching files

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -15,20 +15,6 @@ macro_rules! _function_name {
     }};
 }
 
-// If INSTA_WORKSPACE_ROOT environment variable is set, use the value as-is.
-// This is useful where CARGO_MANIFEST_DIR at compilation points to some
-// transient location. This can easily happen when building the test in one
-// directory but running it in another.
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _get_workspace_root {
-    () => {{
-        use std::env;
-
-        env::var("INSTA_WORKSPACE_ROOT").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string())
-    }};
-}
-
 /// Asserts a `Serialize` snapshot in CSV format.
 ///
 /// **Feature:** `csv` (disabled by default)
@@ -363,7 +349,7 @@ macro_rules! _assert_snapshot_base {
             $name.into(),
             #[allow(clippy::redundant_closure_call)]
             &$transform(&$value),
-            &$crate::_get_workspace_root!(),
+            env!("CARGO_MANIFEST_DIR"),
             $crate::_function_name!(),
             module_path!(),
             file!(),
@@ -501,7 +487,7 @@ macro_rules! with_settings {
 macro_rules! glob {
     ($base_path:expr, $glob:expr, $closure:expr) => {{
         use std::path::Path;
-        let base = $crate::_macro_support::get_cargo_workspace(&$crate::_get_workspace_root!())
+        let base = $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
             .join(Path::new(file!()).parent().unwrap())
             .join($base_path)
             .to_path_buf();
@@ -509,7 +495,7 @@ macro_rules! glob {
         // we try to canonicalize but on some platforms (eg: wasm) that might not work, so
         // we instead silently fall back.
         let base = base.canonicalize().unwrap_or_else(|_| base);
-        $crate::_macro_support::glob_exec(&$crate::_get_workspace_root!(), &base, $glob, $closure);
+        $crate::_macro_support::glob_exec(env!("CARGO_MANIFEST_DIR"), &base, $glob, $closure);
     }};
 
     ($glob:expr, $closure:expr) => {{

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -15,6 +15,23 @@ macro_rules! _function_name {
     }};
 }
 
+// If INSTA_WORKSPACE_ROOT environment variable is set, use the value as-is.
+// This is useful where CARGO_MANIFEST_DIR at compilation points to some
+// transient location. This can easily happen when building the test in one
+// directory but running it in another.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _get_workspace_root {
+    () => {{
+        use std::env;
+
+        // Note the `env!("CARGO_MANIFEST_DIR")` needs to be in the macro rather
+        // than a function because the macro is expanded at the call site and
+        // needs to capture the value in the caller lib.
+        $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
+    }};
+}
+
 /// Asserts a `Serialize` snapshot in CSV format.
 ///
 /// **Feature:** `csv` (disabled by default)
@@ -349,7 +366,7 @@ macro_rules! _assert_snapshot_base {
             $name.into(),
             #[allow(clippy::redundant_closure_call)]
             &$transform(&$value),
-            env!("CARGO_MANIFEST_DIR"),
+            $crate::_get_workspace_root!().as_path(),
             $crate::_function_name!(),
             module_path!(),
             file!(),
@@ -486,8 +503,12 @@ macro_rules! with_settings {
 #[macro_export]
 macro_rules! glob {
     ($base_path:expr, $glob:expr, $closure:expr) => {{
+        // TODO: I think we could remove the three-argument version of this
+        // macro and just support a pattern such as `glob!("../test_data/inputs/*.txt"...`.
+
         use std::path::Path;
-        let base = $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
+
+        let base = $crate::_get_workspace_root!()
             .join(Path::new(file!()).parent().unwrap())
             .join($base_path)
             .to_path_buf();
@@ -495,7 +516,12 @@ macro_rules! glob {
         // we try to canonicalize but on some platforms (eg: wasm) that might not work, so
         // we instead silently fall back.
         let base = base.canonicalize().unwrap_or_else(|_| base);
-        $crate::_macro_support::glob_exec(env!("CARGO_MANIFEST_DIR"), &base, $glob, $closure);
+        $crate::_macro_support::glob_exec(
+            $crate::_get_workspace_root!().as_path(),
+            &base,
+            $glob,
+            $closure,
+        );
     }};
 
     ($glob:expr, $closure:expr) => {{

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -25,11 +25,7 @@ macro_rules! _get_workspace_root {
     () => {{
         use std::env;
 
-        if let Ok(workspace_root) = env::var("INSTA_WORKSPACE_ROOT") {
-            workspace_root.to_string()
-        } else {
-            env!("CARGO_MANIFEST_DIR").to_string()
-        }
+        env::var("INSTA_WORKSPACE_ROOT").unwrap_or_else(|_| env!("CARGO_MANIFEST_DIR").to_string())
     }};
 }
 

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -15,6 +15,24 @@ macro_rules! _function_name {
     }};
 }
 
+// If INSTA_WORKSPACE_ROOT environment variable is set, use the value as-is.
+// This is useful where CARGO_MANIFEST_DIR at compilation points to some
+// transient location. This can easily happen when building the test in one
+// directory but running it in another.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! _get_workspace_root {
+    () => {{
+        use std::env;
+
+        if let Ok(workspace_root) = env::var("INSTA_WORKSPACE_ROOT") {
+            workspace_root.to_string()
+        } else {
+            env!("CARGO_MANIFEST_DIR").to_string()
+        }
+    }};
+}
+
 /// Asserts a `Serialize` snapshot in CSV format.
 ///
 /// **Feature:** `csv` (disabled by default)
@@ -349,7 +367,7 @@ macro_rules! _assert_snapshot_base {
             $name.into(),
             #[allow(clippy::redundant_closure_call)]
             &$transform(&$value),
-            env!("CARGO_MANIFEST_DIR"),
+            &$crate::_get_workspace_root!(),
             $crate::_function_name!(),
             module_path!(),
             file!(),
@@ -487,7 +505,7 @@ macro_rules! with_settings {
 macro_rules! glob {
     ($base_path:expr, $glob:expr, $closure:expr) => {{
         use std::path::Path;
-        let base = $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
+        let base = $crate::_macro_support::get_cargo_workspace(&$crate::_get_workspace_root!())
             .join(Path::new(file!()).parent().unwrap())
             .join($base_path)
             .to_path_buf();
@@ -495,7 +513,7 @@ macro_rules! glob {
         // we try to canonicalize but on some platforms (eg: wasm) that might not work, so
         // we instead silently fall back.
         let base = base.canonicalize().unwrap_or_else(|_| base);
-        $crate::_macro_support::glob_exec(env!("CARGO_MANIFEST_DIR"), &base, $glob, $closure);
+        $crate::_macro_support::glob_exec(&$crate::_get_workspace_root!(), &base, $glob, $closure);
     }};
 
     ($glob:expr, $closure:expr) => {{

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -15,19 +15,15 @@ macro_rules! _function_name {
     }};
 }
 
-// If INSTA_WORKSPACE_ROOT environment variable is set, use the value as-is.
-// This is useful where CARGO_MANIFEST_DIR at compilation points to some
-// transient location. This can easily happen when building the test in one
-// directory but running it in another.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _get_workspace_root {
     () => {{
         use std::env;
 
-        // Note the `env!("CARGO_MANIFEST_DIR")` needs to be in the macro rather
-        // than a function because the macro is expanded at the call site and
-        // needs to capture the value in the caller lib.
+        // Note the `env!("CARGO_MANIFEST_DIR")` needs to be in the macro (in
+        // contrast to a function in insta) because the macro needs to capture
+        // the value in the caller library, an exclusive property of macros.
         $crate::_macro_support::get_cargo_workspace(env!("CARGO_MANIFEST_DIR"))
     }};
 }

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -498,10 +498,10 @@ macro_rules! with_settings {
 #[cfg_attr(docsrs, doc(cfg(feature = "glob")))]
 #[macro_export]
 macro_rules! glob {
+    // TODO: I think we could remove the three-argument version of this macro
+    // and just support a pattern such as
+    // `glob!("../test_data/inputs/*.txt"...`.
     ($base_path:expr, $glob:expr, $closure:expr) => {{
-        // TODO: I think we could remove the three-argument version of this
-        // macro and just support a pattern such as `glob!("../test_data/inputs/*.txt"...`.
-
         use std::path::Path;
 
         let base = $crate::_get_workspace_root!()

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -639,8 +639,6 @@ pub fn assert_snapshot(
         assertion_line,
     )?;
 
-    let tool_config = get_tool_config(manifest_dir);
-
     // apply filters if they are available
     #[cfg(feature = "filters")]
     let new_snapshot_value =
@@ -671,7 +669,7 @@ pub fn assert_snapshot(
         .old_snapshot
         .as_ref()
         .map(|x| {
-            if tool_config.require_full_match() {
+            if ctx.tool_config.require_full_match() {
                 x.matches_fully(&new_snapshot)
             } else {
                 x.matches(&new_snapshot)
@@ -683,7 +681,7 @@ pub fn assert_snapshot(
         ctx.cleanup_passing()?;
 
         if matches!(
-            tool_config.snapshot_update(),
+            ctx.tool_config.snapshot_update(),
             crate::env::SnapshotUpdate::Force
         ) {
             // Avoid creating new files if contents match exactly. In

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -8,14 +8,14 @@ use std::str;
 use std::sync::{Arc, Mutex};
 use std::{borrow::Cow, env};
 
-use crate::output::SnapshotPrinter;
 use crate::settings::Settings;
 use crate::snapshot::{MetaData, PendingInlineSnapshot, Snapshot, SnapshotContents};
 use crate::utils::{path_to_storage, style};
+use crate::{env::get_tool_config, output::SnapshotPrinter};
 use crate::{
     env::{
-        get_cargo_workspace, get_tool_config, memoize_snapshot_file, snapshot_update_behavior,
-        OutputBehavior, SnapshotUpdateBehavior, ToolConfig,
+        memoize_snapshot_file, snapshot_update_behavior, OutputBehavior, SnapshotUpdateBehavior,
+        ToolConfig,
     },
     snapshot::SnapshotKind,
 };
@@ -207,7 +207,7 @@ fn get_snapshot_filename(
 #[derive(Debug)]
 struct SnapshotAssertionContext<'a> {
     tool_config: Arc<ToolConfig>,
-    cargo_workspace: Arc<PathBuf>,
+    workspace: &'a Path,
     module_path: &'a str,
     snapshot_name: Option<Cow<'a, str>>,
     snapshot_file: Option<PathBuf>,
@@ -222,14 +222,13 @@ struct SnapshotAssertionContext<'a> {
 impl<'a> SnapshotAssertionContext<'a> {
     fn prepare(
         refval: ReferenceValue<'a>,
-        manifest_dir: &'a str,
+        workspace: &'a Path,
         function_name: &'a str,
         module_path: &'a str,
         assertion_file: &'a str,
         assertion_line: u32,
     ) -> Result<SnapshotAssertionContext<'a>, Box<dyn Error>> {
-        let tool_config = get_tool_config(manifest_dir);
-        let cargo_workspace = get_cargo_workspace(manifest_dir);
+        let tool_config = get_tool_config(workspace);
         let snapshot_name;
         let mut duplication_key = None;
         let mut snapshot_file = None;
@@ -257,7 +256,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                     module_path,
                     assertion_file,
                     &name,
-                    &cargo_workspace,
+                    workspace,
                     assertion_file,
                     is_doctest,
                 );
@@ -279,7 +278,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                 snapshot_name = detect_snapshot_name(function_name, module_path)
                     .ok()
                     .map(Cow::Owned);
-                let mut pending_file = cargo_workspace.join(assertion_file);
+                let mut pending_file = workspace.join(assertion_file);
                 pending_file.set_file_name(format!(
                     ".{}.pending-snap",
                     pending_file
@@ -300,7 +299,7 @@ impl<'a> SnapshotAssertionContext<'a> {
 
         Ok(SnapshotAssertionContext {
             tool_config,
-            cargo_workspace,
+            workspace,
             module_path,
             snapshot_name,
             snapshot_file,
@@ -315,8 +314,8 @@ impl<'a> SnapshotAssertionContext<'a> {
 
     /// Given a path returns the local path within the workspace.
     pub fn localize_path(&self, p: &Path) -> Option<PathBuf> {
-        let workspace = self.cargo_workspace.canonicalize().ok()?;
-        let p = self.cargo_workspace.join(p).canonicalize().ok()?;
+        let workspace = self.workspace.canonicalize().ok()?;
+        let p = self.workspace.join(p).canonicalize().ok()?;
         p.strip_prefix(&workspace).ok().map(|x| x.to_path_buf())
     }
 
@@ -458,11 +457,7 @@ fn prevent_inline_duplicate(function_name: &str, assertion_file: &str, assertion
 
 /// This prints the information about the snapshot
 fn print_snapshot_info(ctx: &SnapshotAssertionContext, new_snapshot: &Snapshot) {
-    let mut printer = SnapshotPrinter::new(
-        ctx.cargo_workspace.as_path(),
-        ctx.old_snapshot.as_ref(),
-        new_snapshot,
-    );
+    let mut printer = SnapshotPrinter::new(ctx.workspace, ctx.old_snapshot.as_ref(), new_snapshot);
     printer.set_line(Some(ctx.assertion_line));
     printer.set_snapshot_file(ctx.snapshot_file.as_deref());
     printer.set_title(Some("Snapshot Summary"));
@@ -572,8 +567,7 @@ fn record_snapshot_duplicate(
     if let Some(prev_snapshot) = results.get(key) {
         if prev_snapshot.contents() != snapshot.contents() {
             println!("Snapshots in allow-duplicates block do not match.");
-            let mut printer =
-                SnapshotPrinter::new(ctx.cargo_workspace.as_path(), Some(prev_snapshot), snapshot);
+            let mut printer = SnapshotPrinter::new(ctx.workspace, Some(prev_snapshot), snapshot);
             printer.set_line(Some(ctx.assertion_line));
             printer.set_snapshot_file(ctx.snapshot_file.as_deref());
             printer.set_title(Some("Differences in Block"));
@@ -623,7 +617,7 @@ where
 pub fn assert_snapshot(
     refval: ReferenceValue,
     new_snapshot_value: &str,
-    manifest_dir: &str,
+    workspace: &Path,
     function_name: &str,
     module_path: &str,
     assertion_file: &str,
@@ -632,7 +626,7 @@ pub fn assert_snapshot(
 ) -> Result<(), Box<dyn Error>> {
     let ctx = SnapshotAssertionContext::prepare(
         refval,
-        manifest_dir,
+        workspace,
         function_name,
         module_path,
         assertion_file,


### PR DESCRIPTION
Intended to fix #575. Though after some iterations, it ends up being a code-clean-up. I'm not sure how `CARGO_MANIFEST_DIR` is leaking through — it's only referenced by `env!` rather than `env::var`, so should only matter at compile time.

Added a pretty thorough integration test (albeit maybe a bit too complicated)
