### PR TITLE
chore: fixed `warn(elided_named_lifetimes)`

### DIFF
--- a/insta/src/content/yaml/vendored/emitter.rs
+++ b/insta/src/content/yaml/vendored/emitter.rs
@@ -103,7 +103,7 @@ fn escape_str(wr: &mut dyn fmt::Write, v: &str) -> Result<(), fmt::Error> {
 }
 
 impl<'a> YamlEmitter<'a> {
-    pub fn new(writer: &'a mut dyn fmt::Write) -> YamlEmitter {
+    pub fn new(writer: &'a mut dyn fmt::Write) -> YamlEmitter<'a> {
         YamlEmitter {
             writer,
             best_indent: 2,


### PR DESCRIPTION
This fixes an instance of [`warn(elided_named_lifetimes)`](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.ELIDED_NAMED_LIFETIMES.html) which should be uncontroversial.

```
warning: elided lifetime has a name
   --> insta/src/content/yaml/vendored/emitter.rs:106:51
    |
105 | impl<'a> YamlEmitter<'a> {
    |      -- lifetime `'a` declared here
106 |     pub fn new(writer: &'a mut dyn fmt::Write) -> YamlEmitter {
    |                                                   ^^^^^^^^^^^ this elided lifetime gets resolved as `'a`
    |
    = note: `#[warn(elided_named_lifetimes)]` on by default

warning: `insta` (lib) generated 1 warning
```

I know that this currently only "affects" the nightly compliler. Fixing in case this becomes a warn by default lint in the future ^^

Docs on this lint:
- https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#elided-named-lifetimes
- https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/builtin/static.ELIDED_NAMED_LIFETIMES.html