### PR TITLE
Canonicalize snapshot paths before reducing

### DIFF
--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3.5.0"
 semver = {version = "1.0.7", features = ["serde"]}
 lazy_static = "1.4.0"
 clap = { workspace=true }
+itertools = "0.10.0"
 
 [dev-dependencies]
 walkdir = "2.3.1"


### PR DESCRIPTION
Fixes https://github.com/mitsuhiko/insta/issues/625

As ever, the reason is a bit different from the one I initially understood. It's actually that we're reducing the paths by whether one prefixes the other. But in this case the path is only a prefix before it's canonicalized!

On the upside, this case will now work without `--workspace-root`.
