### PR TITLE
Remove some methods from `SnapshotContents`

### DIFF
--- a/cargo-insta/src/container.rs
+++ b/cargo-insta/src/container.rs
@@ -2,9 +2,9 @@ use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use insta::Snapshot;
 pub(crate) use insta::TextSnapshotKind;
 use insta::_cargo_insta_support::{ContentError, PendingInlineSnapshot};
+use insta::{internals::SnapshotContents, Snapshot};
 
 use crate::inline::FilePatcher;
 
@@ -186,7 +186,10 @@ impl SnapshotContainer {
                     Operation::Accept => {
                         patcher.set_new_content(
                             idx,
-                            snapshot.new.contents().as_string_contents().unwrap(),
+                            match snapshot.new.contents() {
+                                SnapshotContents::Text(c) => c,
+                                _ => unreachable!(),
+                            },
                         );
                         did_accept = true;
                     }

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -542,20 +542,12 @@ impl Snapshot {
         }
     }
 
-    /// The normalized snapshot contents as a String
-    pub fn contents_string(&self) -> Option<String> {
-        match self.contents() {
-            SnapshotContents::Text(contents) => Some(contents.normalize()),
-            SnapshotContents::Binary(_) => None,
-        }
-    }
-
     fn serialize_snapshot(&self, md: &MetaData) -> String {
         let mut buf = yaml::to_string(&md.as_content());
         buf.push_str("---\n");
 
-        if let Some(ref contents_str) = self.contents_string() {
-            buf.push_str(contents_str);
+        if let SnapshotContents::Text(ref contents) = self.snapshot {
+            buf.push_str(&contents.to_string());
             buf.push('\n');
         }
 
@@ -635,13 +627,6 @@ impl From<TextSnapshotContents> for SnapshotContents {
 impl SnapshotContents {
     pub fn is_binary(&self) -> bool {
         matches!(self, SnapshotContents::Binary(_))
-    }
-
-    pub fn as_string_contents(&self) -> Option<&TextSnapshotContents> {
-        match self {
-            SnapshotContents::Text(contents) => Some(contents),
-            SnapshotContents::Binary(_) => None,
-        }
     }
 }
 


### PR DESCRIPTION
Since the binary snapshots have merged, there are some methods which return `Some` if the enum is a certain variant. We can just use pattern matching for that.

(Note that the code is a bit complicated and has lots of repetition of 'kind'-like fields; but wanted to merge the binary snapshots feature before cleaning up the internals
