### PR TITLE
Standardize names for new/old/reference

### DIFF
--- a/cargo-insta/tests/main.rs
+++ b/cargo-insta/tests/main.rs
@@ -1133,8 +1133,8 @@ fn test_wrong_indent_force() {
     // ...and that it passes with `--require-full-match`. Note that ideally this
     // would fail, but we can't read the desired indent without serde, which is
     // in `cargo-insta` only. So this tests the current state rather than the
-    // ideal state (and I don't think there's a reasonable way to get the ideal state)
-    // Now confirm that `--require-full-match` passes
+    // ideal state (and I don't think there's a reasonable way to get the ideal
+    // state).
     let output = test_project
         .insta_cmd()
         .args([

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -376,7 +376,7 @@ impl ToolConfig {
 pub enum SnapshotUpdateBehavior {
     /// Snapshots are updated in-place
     InPlace,
-    /// Snapshots are placed in a new file with a .new suffix
+    /// Snapshots are placed in a new file with a `.new` suffix
     NewFile,
     /// Snapshots are not updated at all.
     NoUpdate,
@@ -495,7 +495,7 @@ impl std::str::FromStr for UnreferencedSnapshots {
     }
 }
 
-/// Memoizes a snapshot file in the reference file, as part of removing unreferenced snapshots.
+/// Memoizes a snapshot file in a reference file, as part of removing unreferenced snapshots.
 pub fn memoize_snapshot_file(snapshot_file: &Path) {
     if let Ok(path) = env::var("INSTA_SNAPSHOT_REFERENCES_FILE") {
         let mut f = fs::OpenOptions::new()

--- a/insta/src/lib.rs
+++ b/insta/src/lib.rs
@@ -9,13 +9,13 @@
 //! # What are snapshot tests
 //!
 //! Snapshots tests (also sometimes called approval tests) are tests that
-//! assert values against a reference value (the snapshot).  This is similar
+//! assert values against an existing value (the snapshot).  This is similar
 //! to how [`assert_eq!`] lets you compare a value against a reference value but
 //! unlike simple string assertions, snapshot tests let you test against complex
 //! values and come with comprehensive tools to review changes.
 //!
-//! Snapshot tests are particularly useful if your reference values are very
-//! large or change often.
+//! Snapshot tests are particularly useful for values which are large or change
+//! often.
 //!
 //! # What it looks like:
 //!

--- a/insta/src/macros.rs
+++ b/insta/src/macros.rs
@@ -127,8 +127,8 @@ macro_rules! assert_toml_snapshot {
 ///
 /// The replacement value can be a string, integer or any other primitive value.
 ///
-/// For inline usage the format is `(expression, @reference_value)` where the
-/// reference value must be a string literal.  If you make the initial snapshot
+/// For inline usage the format is `(expression, @value)` where the
+/// value must be a string literal.  If you make the initial snapshot
 /// just use an empty string (`@""`).
 ///
 /// The snapshot name is optional but can be provided as first argument.
@@ -437,11 +437,11 @@ macro_rules! assert_display_snapshot {
 /// ```no_run
 /// # use insta::*;
 /// // implicitly named
-/// assert_snapshot!("reference value to snapshot");
+/// assert_snapshot!("value to snapshot");
 /// // named
-/// assert_snapshot!("snapshot_name", "reference value to snapshot");
+/// assert_snapshot!("snapshot_name", "value to snapshot");
 /// // inline
-/// assert_snapshot!("reference value", @"reference value");
+/// assert_snapshot!("value", @"value");
 /// ```
 ///
 /// Optionally a third argument can be given as an expression to be stringified


### PR DESCRIPTION
As discussed in #613.

After doing this, there isn't as much disagreement as I had remembered -- I think we reduced the use of `ReferenceValue` recently as a side-effect of other work. So it's mostly changing names from `old` & `new` to `existing` & `generated`/`proposed`.

Opening the PR but will leave for a few days to consider whether it's worthwhile
