### PR TITLE
Better deprecation warning for `--no-force-pass`

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -644,11 +644,12 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
             cmd.force_update_snapshots = true;
         }
     }
-
-    // --check always implies --no-force-pass as otherwise this command does not
-    // make a lot of sense.
-    if cmd.check {
-        cmd.no_force_pass = true
+    if cmd.no_force_pass {
+        cmd.check = true;
+        eprintln!(
+            "{}: `--no-force-pass` is deprecated. Please use --check to immediately raise an error on any non-matching snapshots.",
+            style("warning").bold().yellow()
+        )
     }
 
     // the tool config can also indicate that --accept-unseen should be picked
@@ -998,15 +999,6 @@ fn prepare_test_runner<'snapshot_ref>(
     }
     if !cmd.check {
         proc.env("INSTA_FORCE_PASS", "1");
-    } else if !cmd.no_force_pass {
-        proc.env("INSTA_FORCE_PASS", "1");
-        // If we're not running under cargo insta, raise a warning that this option
-        // is deprecated. (cargo insta still uses it when running under `--check`,
-        // but this will stop soon too)
-        eprintln!(
-            "{}: `--no-force-pass` is deprecated. Please use --check to immediately raise an error on any non-matching snapshots.",
-            style("warning").bold().yellow()
-    );
     }
 
     proc.env(

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -385,7 +385,7 @@ impl Snapshot {
                     }
                 }
             }
-            elog!("A snapshot uses an old snapshot format; please update it to the new format with `cargo insta test --force-update-snapshots --accept`.\n\nSnapshot is at: {}", p.to_string_lossy());
+            elog!("A snapshot uses a legacy snapshot format; please update it to the new format with `cargo insta test --force-update-snapshots --accept`.\n\nSnapshot is at: {}", p.to_string_lossy());
             rv
         };
 
@@ -752,7 +752,7 @@ impl PartialEq for SnapshotContents {
                 if this.matches_latest(other) {
                     true
                 } else if this.matches_legacy(other) {
-                    elog!("{} {}\n{}",style("Snapshot passes but is a legacy format. Please run `cargo insta test --force-update-snapshots --accept` to update to a newer format.").yellow().bold(),"Snapshot contents:", this.to_string());
+                    elog!("{} {}\n{}",style("Snapshot test passes but the existing value is in a legacy format. Please run `cargo insta test --force-update-snapshots` to update to a newer format.").yellow().bold(),"Snapshot contents:", this.to_string());
                     true
                 } else {
                     false


### PR DESCRIPTION
Not sure the old code was working, this is simpler
