### PR TITLE
Add warning about stability to doc comment for internals module

### DIFF
--- a/insta/src/lib.rs
+++ b/insta/src/lib.rs
@@ -300,6 +300,9 @@ pub use crate::snapshot::{MetaData, Snapshot, TextSnapshotKind};
 ///
 /// You're unlikely to want to work with these objects but they
 /// are exposed for documentation primarily.
+///
+/// This module does not follow the same stability guarantees as the rest of the crate and is not
+/// guaranteed to be compatible between minor versions.
 pub mod internals {
     pub use crate::content::Content;
     #[cfg(feature = "filters")]


### PR DESCRIPTION
As discussed in #610 it probably makes sense to be explicit about the `internals` module not being guaranteed to be stable.

I also noticed that `TextSnapshotKind` gets exposed globally. This was added in #581 when it was still called `SnapshotKind`. I wonder if this is necessary to expose toplevel.