### PR TITLE
chore: updating cargo lock for ron/toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +362,16 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -717,6 +739,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,11 +848,36 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1136,3 +1192,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -11,9 +11,7 @@ repository = "https://github.com/mitsuhiko/insta"
 keywords = ["snapshot", "testing", "jest", "approval"]
 categories = ["development-tools::testing"]
 readme = "README.md"
-exclude = [
-    "assets/*"
-]
+exclude = ["assets/*"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -51,17 +49,20 @@ console = { version = "0.15.4", optional = true, default-features = false }
 pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.7.1", optional = true }
-toml = { version = "0.5.7", optional = true }
+toml = { version = "0.8.19", optional = true }
 globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }
-regex = { version = "1.6.0", default-features = false, optional = true, features = ["std", "unicode"] }
+regex = { version = "1.6.0", default-features = false, optional = true, features = [
+    "std",
+    "unicode",
+] }
 serde = { version = "1.0.117", optional = true }
 linked-hash-map = "0.5.6"
 lazy_static = "1.4.0"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }
-clap = {version = "4.1", features = ["derive", "env"], optional = true}
+clap = { version = "4.1", features = ["derive", "env"], optional = true }
 
 [dev-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
This PR updates `toml` dependency to avoid discrepancy between the latest `toml` version and the one in `insta`.

When refactoring some part of the configuration on one of my project that is using `toml`, I discovered that my configuration was properly serialized when using `toml = 0.8.x` while when using in `insta` it was failing with`UnsupportedType`. After digging a bit, it is related to [this](https://github.com/toml-rs/toml/issues/553).


To reproduce on a fresh `cargo new --lib` :

`Cargo.toml`
```toml
[dependencies]
serde = { version = "1.0.210", features = ["derive"] }
toml_5 = { package = "toml", version = "0.5" }
toml_8 = { package = "toml", version = "0.8" }
```

`lib.rs`
```rust
use serde::Serialize;

#[derive(Serialize)]
enum SomeType {
    Type1 {},
    Type2 {},
}

impl Default for SomeType {
    fn default() -> Self {
        SomeType::Type1 {}
    }
}

#[derive(Serialize, Default)]
struct Config {
    #[serde(default)]
    some_type: SomeType,
}

#[cfg(test)]
mod tests {
    use super::*;

    #[test]
    #[should_panic]
    fn toml_5_test_serialize_config_fails() {
        let cfg = Config::default();

        toml_5::to_string_pretty(&cfg).unwrap();
    }

    #[test]
    fn toml_8_test_serialize_config_ok() {
        let cfg = Config::default();

        toml_8::to_string_pretty(&cfg).unwrap();
    }
}
```