### PR TITLE
Replace `lazy_static` with `once_cell`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target
 .vscode/*.log
 .aider*
 .env
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,6 @@ dependencies = [
  "ignore",
  "insta",
  "itertools",
- "lazy_static",
  "open",
  "os_pipe",
  "proc-macro2",
@@ -360,8 +359,8 @@ dependencies = [
  "console",
  "csv",
  "globset",
- "lazy_static",
  "linked-hash-map",
+ "once_cell",
  "pest",
  "pest_derive",
  "regex",
@@ -486,12 +485,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.1"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
-dependencies = [
- "portable-atomic",
-]
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "open"
@@ -564,12 +560,6 @@ dependencies = [
  "pest",
  "sha2",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "proc-macro2"

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -33,7 +33,6 @@ uuid = { version = "1.0.0", features = ["v4"] }
 tempfile = "3.5.0"
 # Needs pinning in Cargo.lock because of MSRV
 semver = { version = "1.0.7", features = ["serde"] }
-lazy_static = "1.4.0"
 clap = { workspace = true }
 open = "5.3.0"
 itertools = "0.10.0"

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -59,7 +59,7 @@ regex = { version = "1.6.0", default-features = false, optional = true, features
 ] }
 serde = { version = "1.0.117", optional = true }
 linked-hash-map = "0.5.6"
-lazy_static = "1.4.0"
+once_cell = "1.20.2"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }
 clap = { version = "4.1", features = ["derive", "env"], optional = true }

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -10,10 +10,12 @@ use crate::{
     elog,
 };
 
-lazy_static::lazy_static! {
-    static ref WORKSPACES: Mutex<BTreeMap<String, Arc<PathBuf>>> = Mutex::new(BTreeMap::new());
-    static ref TOOL_CONFIGS: Mutex<BTreeMap<PathBuf, Arc<ToolConfig>>> = Mutex::new(BTreeMap::new());
-}
+use once_cell::sync::Lazy;
+
+static WORKSPACES: Lazy<Mutex<BTreeMap<String, Arc<PathBuf>>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+static TOOL_CONFIGS: Lazy<Mutex<BTreeMap<PathBuf, Arc<ToolConfig>>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
 
 pub fn get_tool_config(workspace_dir: &Path) -> Arc<ToolConfig> {
     TOOL_CONFIGS

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 use globset::{GlobBuilder, GlobMatcher};
+use once_cell::sync::Lazy;
 use walkdir::WalkDir;
 
 use crate::env::get_tool_config;
@@ -15,28 +16,22 @@ pub(crate) struct GlobCollector {
     pub(crate) show_insta_hint: bool,
 }
 
-lazy_static::lazy_static! {
-    /// the glob stack holds failure count and an indication if `cargo insta review`
-    /// should be run.
-    pub(crate) static ref GLOB_STACK: Mutex<Vec<GlobCollector>> = Mutex::default();
-}
+/// the glob stack holds failure count and an indication if `cargo insta review`
+/// should be run.
+pub(crate) static GLOB_STACK: Lazy<Mutex<Vec<GlobCollector>>> = Lazy::new(|| Mutex::default());
 
-lazy_static::lazy_static! {
-    static ref GLOB_FILTER: Vec<GlobMatcher> = {
-        env::var("INSTA_GLOB_FILTER")
-            .unwrap_or_default()
-            .split(';')
-            .filter(|x| !x.is_empty())
-            .filter_map(|filter| {
-                GlobBuilder::new(filter)
-                    .case_insensitive(true)
-                    .build()
-                    .ok()
-                    .map(|x| x.compile_matcher())
-            })
-            .collect()
-    };
-}
+static GLOB_FILTER: Lazy<Vec<GlobMatcher>> = Lazy::new(|| env::var("INSTA_GLOB_FILTER")
+    .unwrap_or_default()
+    .split(';')
+    .filter(|x| !x.is_empty())
+    .filter_map(|filter| {
+        GlobBuilder::new(filter)
+            .case_insensitive(true)
+            .build()
+            .ok()
+            .map(|x| x.compile_matcher())
+    })
+    .collect());
 
 pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &str, mut f: F) {
     // If settings.allow_empty_glob() == true and `base` doesn't exist, skip

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -20,18 +20,20 @@ pub(crate) struct GlobCollector {
 /// should be run.
 pub(crate) static GLOB_STACK: Lazy<Mutex<Vec<GlobCollector>>> = Lazy::new(|| Mutex::default());
 
-static GLOB_FILTER: Lazy<Vec<GlobMatcher>> = Lazy::new(|| env::var("INSTA_GLOB_FILTER")
-    .unwrap_or_default()
-    .split(';')
-    .filter(|x| !x.is_empty())
-    .filter_map(|filter| {
-        GlobBuilder::new(filter)
-            .case_insensitive(true)
-            .build()
-            .ok()
-            .map(|x| x.compile_matcher())
-    })
-    .collect());
+static GLOB_FILTER: Lazy<Vec<GlobMatcher>> = Lazy::new(|| {
+    env::var("INSTA_GLOB_FILTER")
+        .unwrap_or_default()
+        .split(';')
+        .filter(|x| !x.is_empty())
+        .filter_map(|filter| {
+            GlobBuilder::new(filter)
+                .case_insensitive(true)
+                .build()
+                .ok()
+                .map(|x| x.compile_matcher())
+        })
+        .collect()
+});
 
 pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &str, mut f: F) {
     // If settings.allow_empty_glob() == true and `base` doesn't exist, skip

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -23,14 +23,13 @@ use crate::{
     snapshot::TextSnapshotKind,
 };
 
-lazy_static::lazy_static! {
-    static ref TEST_NAME_COUNTERS: Mutex<BTreeMap<String, usize>> =
-        Mutex::new(BTreeMap::new());
-    static ref TEST_NAME_CLASH_DETECTION: Mutex<BTreeMap<String, bool>> =
-        Mutex::new(BTreeMap::new());
-    static ref INLINE_DUPLICATES: Mutex<BTreeSet<String>> =
-        Mutex::new(BTreeSet::new());
-}
+use once_cell::sync::Lazy;
+
+static TEST_NAME_COUNTERS: Lazy<Mutex<BTreeMap<String, usize>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+static TEST_NAME_CLASH_DETECTION: Lazy<Mutex<BTreeMap<String, bool>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+static INLINE_DUPLICATES: Lazy<Mutex<BTreeSet<String>>> = Lazy::new(|| Mutex::new(BTreeSet::new()));
 
 thread_local! {
     static RECORDED_DUPLICATES: RefCell<Vec<BTreeMap<String, Snapshot>>> = RefCell::default()

--- a/insta/src/settings.rs
+++ b/insta/src/settings.rs
@@ -1,3 +1,6 @@
+use once_cell::sync::Lazy;
+#[cfg(feature = "serde")]
+use serde::{de::value::Error as ValueError, Serialize};
 use std::cell::RefCell;
 use std::future::Future;
 use std::mem;
@@ -5,9 +8,6 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-
-#[cfg(feature = "serde")]
-use serde::{de::value::Error as ValueError, Serialize};
 
 use crate::content::Content;
 #[cfg(feature = "serde")]
@@ -17,26 +17,23 @@ use crate::filters::Filters;
 #[cfg(feature = "redactions")]
 use crate::redaction::{dynamic_redaction, sorted_redaction, ContentPath, Redaction, Selector};
 
-lazy_static::lazy_static! {
-    static ref DEFAULT_SETTINGS: Arc<ActualSettings> = {
-        Arc::new(ActualSettings {
-            sort_maps: false,
-            snapshot_path: "snapshots".into(),
-            snapshot_suffix: "".into(),
-            input_file: None,
-            description: None,
-            info: None,
-            omit_expression: false,
-            prepend_module_to_snapshot: true,
-            #[cfg(feature = "redactions")]
-            redactions: Redactions::default(),
-            #[cfg(feature = "filters")]
-            filters: Filters::default(),
-            #[cfg(feature = "glob")]
-            allow_empty_glob: false,
-        })
-    };
-}
+static DEFAULT_SETTINGS: Lazy<Arc<ActualSettings>> = Lazy::new(|| Arc::new(ActualSettings {
+    sort_maps: false,
+    snapshot_path: "snapshots".into(),
+    snapshot_suffix: "".into(),
+    input_file: None,
+    description: None,
+    info: None,
+    omit_expression: false,
+    prepend_module_to_snapshot: true,
+    #[cfg(feature = "redactions")]
+    redactions: Redactions::default(),
+    #[cfg(feature = "filters")]
+    filters: Filters::default(),
+    #[cfg(feature = "glob")]
+    allow_empty_glob: false,
+}));
+
 thread_local!(static CURRENT_SETTINGS: RefCell<Settings> = RefCell::new(Settings::new()));
 
 /// Represents stored redactions.

--- a/insta/src/settings.rs
+++ b/insta/src/settings.rs
@@ -17,22 +17,24 @@ use crate::filters::Filters;
 #[cfg(feature = "redactions")]
 use crate::redaction::{dynamic_redaction, sorted_redaction, ContentPath, Redaction, Selector};
 
-static DEFAULT_SETTINGS: Lazy<Arc<ActualSettings>> = Lazy::new(|| Arc::new(ActualSettings {
-    sort_maps: false,
-    snapshot_path: "snapshots".into(),
-    snapshot_suffix: "".into(),
-    input_file: None,
-    description: None,
-    info: None,
-    omit_expression: false,
-    prepend_module_to_snapshot: true,
-    #[cfg(feature = "redactions")]
-    redactions: Redactions::default(),
-    #[cfg(feature = "filters")]
-    filters: Filters::default(),
-    #[cfg(feature = "glob")]
-    allow_empty_glob: false,
-}));
+static DEFAULT_SETTINGS: Lazy<Arc<ActualSettings>> = Lazy::new(|| {
+    Arc::new(ActualSettings {
+        sort_maps: false,
+        snapshot_path: "snapshots".into(),
+        snapshot_suffix: "".into(),
+        input_file: None,
+        description: None,
+        info: None,
+        omit_expression: false,
+        prepend_module_to_snapshot: true,
+        #[cfg(feature = "redactions")]
+        redactions: Redactions::default(),
+        #[cfg(feature = "filters")]
+        filters: Filters::default(),
+        #[cfg(feature = "glob")]
+        allow_empty_glob: false,
+    })
+});
 
 thread_local!(static CURRENT_SETTINGS: RefCell<Settings> = RefCell::new(Settings::new()));
 

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -1,3 +1,9 @@
+use crate::{
+    content::{self, json, yaml, Content},
+    elog,
+    utils::style,
+};
+use once_cell::sync::Lazy;
 use std::env;
 use std::error::Error;
 use std::fs;
@@ -7,22 +13,12 @@ use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{borrow::Cow, fmt};
 
-use crate::{
-    content::{self, json, yaml, Content},
-    elog,
-    utils::style,
-};
-
-lazy_static::lazy_static! {
-    static ref RUN_ID: String = {
-        if let Ok(run_id) = env::var("NEXTEST_RUN_ID") {
-            run_id
-        } else {
-            let d = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-            format!("{}-{}", d.as_secs(), d.subsec_nanos())
-        }
-    };
-}
+static RUN_ID: Lazy<String> = Lazy::new(|| if let Ok(run_id) = env::var("NEXTEST_RUN_ID") {
+    run_id
+} else {
+    let d = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    format!("{}-{}", d.as_secs(), d.subsec_nanos())
+});
 
 /// Holds a pending inline snapshot loaded from a json file or read from an assert
 /// macro (doesn't write to the rust file, which is done by `cargo-insta`)

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -13,11 +13,13 @@ use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{borrow::Cow, fmt};
 
-static RUN_ID: Lazy<String> = Lazy::new(|| if let Ok(run_id) = env::var("NEXTEST_RUN_ID") {
-    run_id
-} else {
-    let d = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-    format!("{}-{}", d.as_secs(), d.subsec_nanos())
+static RUN_ID: Lazy<String> = Lazy::new(|| {
+    if let Ok(run_id) = env::var("NEXTEST_RUN_ID") {
+        run_id
+    } else {
+        let d = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        format!("{}-{}", d.as_secs(), d.subsec_nanos())
+    }
 });
 
 /// Holds a pending inline snapshot loaded from a json file or read from an assert


### PR DESCRIPTION
Hi, since both crates are now on MSRV >= 1.60, we can now use `once_cell` over `lazy_static` [0]

[0] https://github.com/matklad/once_cell/blob/4fbd4a53509ca59c8e09efc2ab0a22f21de70f7e/Cargo.toml#L7