### PR TITLE
Update test output for `snapshot_text` change

### DIFF
--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -375,13 +375,12 @@ Hello, world!
     assert_snapshot!(test_insta_1_40_0.diff("src/snapshots/test_force_update_1_40_0__force_update.snap"), @r#"
     --- Original: src/snapshots/test_force_update_1_40_0__force_update.snap
     +++ Updated: src/snapshots/test_force_update_1_40_0__force_update.snap
-    @@ -1,8 +1,6 @@
+    @@ -1,8 +1,5 @@
     -
      ---
      source: src/lib.rs
     -expression: 
     +expression: "\"Hello, world!\""
-    +snapshot_kind: text
      ---
      Hello, world!
     -


### PR DESCRIPTION
This broke on updating the tag to 1.42. I don't know exactly why and 5 minutes of looking through wasn't enough. That's not a great state to be in, but merging to ensure test pass on `master`