### PR TITLE
Switch from pin-project to pin-project-lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
- "pin-project",
+ "pin-project-lite",
  "regex",
  "ron",
  "rustc_version",
@@ -564,24 +564,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.8"
+name = "pin-project-lite"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -63,7 +63,7 @@ once_cell = "1.20.2"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }
 clap = { version = "4.1", features = ["derive", "env"], optional = true }
-pin-project = "1"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
This gets rid of the only proc macro dependency of insta. Both pin-project and pin-project-lite are maintained by the same person.