### PR TITLE
Remove pin-project dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,6 @@ dependencies = [
  "once_cell",
  "pest",
  "pest_derive",
- "pin-project-lite",
  "regex",
  "ron",
  "rustc_version",
@@ -562,12 +561,6 @@ dependencies = [
  "pest",
  "sha2",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "proc-macro2"

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -63,7 +63,6 @@ once_cell = "1.20.2"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }
 clap = { version = "4.1", features = ["derive", "env"], optional = true }
-pin-project-lite = "0.2"
 
 [dev-dependencies]
 rustc_version = "0.4.0"


### PR DESCRIPTION
Reverts #711 and #737.

It's for a singular unsafe on a rather uncommon path, that is not worth pulling dependencies in.