### PR TITLE
Replace linked-hash-map with a basic hashmap wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "console",
  "csv",
  "globset",
- "linked-hash-map",
  "once_cell",
  "pest",
  "pest_derive",
@@ -456,12 +455,6 @@ name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -58,7 +58,6 @@ regex = { version = "1.6.0", default-features = false, optional = true, features
     "unicode",
 ] }
 serde = { version = "1.0.117", optional = true }
-linked-hash-map = "0.5.6"
 once_cell = "1.20.2"
 # Not yet supported in our MSRV of 1.60.0
 # clap = { workspace=true, optional = true }

--- a/insta/src/content/yaml/vendored/hashmap.rs
+++ b/insta/src/content/yaml/vendored/hashmap.rs
@@ -1,0 +1,127 @@
+use std::cmp::Ordering;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[derive(Clone, Debug)]
+pub struct OrderedHashMap<K, V> {
+    map: HashMap<K, V>,
+    key_order: Vec<K>,
+}
+
+impl<K: Hash + Eq + Clone, V> OrderedHashMap<K, V> {
+    pub fn new() -> Self {
+        OrderedHashMap {
+            map: HashMap::new(),
+            key_order: Vec::new(),
+        }
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        match self.map.entry(key) {
+            Entry::Occupied(mut entry) => Some(entry.insert(value)),
+            Entry::Vacant(entry) => {
+                self.key_order.push(entry.key().clone());
+                entry.insert(value);
+                None
+            }
+        }
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.map.get(key)
+    }
+
+    pub fn iter(&self) -> Iter<K, V> {
+        Iter {
+            map: &self.map,
+            keys: self.key_order.iter(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+impl<K: Hash + Eq, V: PartialEq> PartialEq for OrderedHashMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+    }
+}
+
+impl<K: Hash + Eq, V: Eq> Eq for OrderedHashMap<K, V> {}
+
+impl<K: Hash + Eq + PartialOrd + Clone, V: PartialOrd> PartialOrd for OrderedHashMap<K, V> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.iter().partial_cmp(other.iter())
+    }
+}
+
+impl<K: Hash + Eq + Ord + Clone, V: Ord> Ord for OrderedHashMap<K, V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iter().cmp(other.iter())
+    }
+}
+
+impl<K: Hash + Eq + Clone, V: Hash> Hash for OrderedHashMap<K, V> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        for item in self.iter() {
+            item.hash(state);
+        }
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> FromIterator<(K, V)> for OrderedHashMap<K, V> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        let mut map = OrderedHashMap::new();
+        for (k, v) in iter {
+            map.insert(k, v);
+        }
+        map
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> IntoIterator for OrderedHashMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IntoIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter {
+            map: self.map,
+            keys: self.key_order.into_iter(),
+        }
+    }
+}
+
+pub struct IntoIter<K, V> {
+    map: HashMap<K, V>,
+    keys: std::vec::IntoIter<K>,
+}
+
+impl<K: Hash + Eq, V> Iterator for IntoIter<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.keys.next().map(|key| {
+            let value = self.map.remove(&key).unwrap();
+            (key, value)
+        })
+    }
+}
+
+pub struct Iter<'a, K, V> {
+    map: &'a HashMap<K, V>,
+    keys: std::slice::Iter<'a, K>,
+}
+
+impl<'a, K: Hash + Eq, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.keys.next().map(|key| {
+            let value = self.map.get(key).unwrap();
+            (key, value)
+        })
+    }
+}

--- a/insta/src/content/yaml/vendored/mod.rs
+++ b/insta/src/content/yaml/vendored/mod.rs
@@ -8,6 +8,7 @@
 #![allow(unused)]
 
 pub mod emitter;
+pub mod hashmap;
 pub mod parser;
 pub mod scanner;
 pub mod yaml;

--- a/insta/src/content/yaml/vendored/yaml.rs
+++ b/insta/src/content/yaml/vendored/yaml.rs
@@ -1,7 +1,6 @@
+use crate::content::yaml::vendored::hashmap::OrderedHashMap;
 use crate::content::yaml::vendored::parser::*;
 use crate::content::yaml::vendored::scanner::{Marker, ScanError, TScalarStyle, TokenType};
-
-use linked_hash_map::LinkedHashMap;
 
 use std::collections::BTreeMap;
 use std::f64;
@@ -25,7 +24,7 @@ pub enum Yaml {
     Boolean(bool),
     /// YAML array, can be accessed as a `Vec`.
     Array(self::Array),
-    /// YAML hash, can be accessed as a `LinkedHashMap`.
+    /// YAML hash, can be accessed as a `OrderedHashMap`.
     ///
     /// Insertion order will match the order of insertion into the map.
     Hash(self::Hash),
@@ -38,7 +37,7 @@ pub enum Yaml {
 }
 
 pub type Array = Vec<Yaml>;
-pub type Hash = LinkedHashMap<Yaml, Yaml>;
+pub type Hash = OrderedHashMap<Yaml, Yaml>;
 
 // parse f64 as Core schema
 // See: https://github.com/chyh1990/yaml-rust/issues/51


### PR DESCRIPTION
For the limited uses of what insta has, there is not a lot of code needed.  This comes at the cost of storing keys twice, but I believe that this is somewhat acceptable for the uses here.  It would also be possible to replace this entirely with a `Vec<(Yaml, Yaml)>` with a further refactor since the yaml structure isn't really used other than to convert to `Content` in most places.  That does not apply to tests and a handful other places.

Fixes #740