### PR TITLE
Fix test when not in `insta` path

### DIFF
--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -511,8 +511,11 @@ pub fn get_cargo_workspace(workspace: Workspace) -> Arc<PathBuf> {
 #[test]
 fn test_get_cargo_workspace_manifest_dir() {
     let workspace = get_cargo_workspace(Workspace::DetectWithCargo(env!("CARGO_MANIFEST_DIR")));
-    // The absolute path of the workspace, like `/Users/janedoe/projects/insta`
-    assert!(workspace.ends_with("insta"));
+    // The absolute path of the workspace should be a valid directory
+    // In worktrees or other setups, the path might not end with "insta" 
+    // but should still be a parent of the manifest directory
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    assert!(manifest_dir.starts_with(&*workspace));
 }
 
 #[test]

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -512,7 +512,7 @@ pub fn get_cargo_workspace(workspace: Workspace) -> Arc<PathBuf> {
 fn test_get_cargo_workspace_manifest_dir() {
     let workspace = get_cargo_workspace(Workspace::DetectWithCargo(env!("CARGO_MANIFEST_DIR")));
     // The absolute path of the workspace should be a valid directory
-    // In worktrees or other setups, the path might not end with "insta" 
+    // In worktrees or other setups, the path might not end with "insta"
     // but should still be a parent of the manifest directory
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     assert!(manifest_dir.starts_with(&*workspace));


### PR DESCRIPTION
The existing test expects to be in a path that ends with `insta`. In a git worktree that's often not the case.

I think this change may make the test a bit impotent, but it does fix the issue, and I don't think the test is _that_ important. (other ideas welcome as ever)
