### PR TITLE
Bump syn to latest version 2.0.100

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,9 +557,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -745,9 +745,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -25,7 +25,6 @@ console = "0.15.4"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 proc-macro2 = { version = "1.0.60", features = ["span-locations"] }
-# Needs pinning in Cargo.lock because of MSRV
 syn = { version = "2.0.8", features = ["full", "visit", "extra-traits"] }
 # Needs pinning in Cargo.lock because of MSRV
 ignore = "0.4.17"


### PR DESCRIPTION
This fixes parsing of `+ use<'a>` syntax.

"syn" claims to support rustc 1.61, so I think it's compatible with MSRV of cargo-insta.