### PR TITLE
add config for typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default]
+extend-words = { "Foled" = "Foled" }


### PR DESCRIPTION
excludes a current error from `pre-commit`
