### PR TITLE
use fixed tag for `typos`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-yaml
       - id: mixed-line-ending
   - repo: https://github.com/crate-ci/typos
-    rev: v1
+    rev: v1.31.1
     hooks:
       - id: typos
         # https://github.com/crate-ci/typos/issues/347


### PR DESCRIPTION
avoids pre-commit warnings
