### PR TITLE
Add cargo-insta version fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -18,15 +18,20 @@ body:
         2. [Second step]
         3. etc.
   - type: input
-    id: insta-version
-    attributes:
-      label: Insta Version
-      description: What version of insta are you using?
-  - type: input
     id: rustc-version
     attributes:
       label: rustc Version
       description: What version of rustc are you using?
+  - type: input
+    id: cargo-insta-version
+    attributes:
+      label: cargo-insta Version
+      description: What version of cargo-insta are you using? (in Cargo.toml)
+  - type: input
+    id: cargo-insta-command-version
+    attributes:
+      label: cargo insta --version output
+      description: What does `cargo insta --version` output?
   - type: textarea
     id: expectations
     attributes:


### PR DESCRIPTION
Adds fields for `cargo-insta` version and the output of `cargo insta --version` to the bug report issue template. This helps gather necessary information for debugging issues related to the `cargo-insta` command.

Co-authored-by: Claude <no-reply@anthropic.com>
