### PR TITLE
Preserve snapshot names with INSTA_GLOB_FILTER

### DIFF
--- a/cargo-insta/tests/functional/glob_filter.rs
+++ b/cargo-insta/tests/functional/glob_filter.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+/// Test that INSTA_GLOB_FILTER preserves snapshot file names
+///
+/// When using INSTA_GLOB_FILTER to filter glob matches to a single file,
+/// the snapshot name should maintain its file suffix (e.g., "test_name@file.txt.snap")
+/// by using the common prefix from all matches, not just filtered ones.
+#[test]
+fn test_glob_filter_preserves_snapshot_names() {
+    let test_project = TestFiles::new()
+        .add_file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "test_glob_filter"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+insta = { path = '$PROJECT_PATH', features = ["glob"] }
+"#
+            .to_string(),
+        )
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_glob_snapshots() {
+    insta::glob!("data/*.txt", |path| {
+        let content = std::fs::read_to_string(path).unwrap();
+        insta::assert_snapshot!(content);
+    });
+}
+"#
+            .to_string(),
+        )
+        .add_file("src/data/apple.txt", "apple".to_string())
+        .add_file("src/data/banana.txt", "banana".to_string())
+        .add_file("src/data/cherry.txt", "cherry".to_string())
+        .create_project();
+
+    // Run without filter to create initial snapshots
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // Check snapshot names
+    let snapshot_dir = test_project.workspace_dir.join("src/snapshots");
+    let get_snapshot_list = || -> String {
+        let mut names: Vec<_> = std::fs::read_dir(&snapshot_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|name| name.ends_with(".snap"))
+            .collect();
+        names.sort();
+        names.join("\n")
+    };
+
+    assert_snapshot!(get_snapshot_list(), @r###"
+    test_glob_filter__glob_snapshots@apple.txt.snap
+    test_glob_filter__glob_snapshots@banana.txt.snap
+    test_glob_filter__glob_snapshots@cherry.txt.snap
+    "###);
+
+    // Clean and run with INSTA_GLOB_FILTER to filter to single file
+    std::fs::remove_dir_all(&snapshot_dir).unwrap();
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .env("INSTA_GLOB_FILTER", "**/apple.txt")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // When filtered to one file, the snapshot name should keep the file suffix
+    assert_snapshot!(get_snapshot_list(), @"test_glob_filter__glob_snapshots@apple.txt.snap");
+
+    // Verify the fix works with any pattern that matches one file
+    std::fs::remove_dir_all(&snapshot_dir).unwrap();
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .env("INSTA_GLOB_FILTER", "*pple*")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    assert_snapshot!(get_snapshot_list(), @"test_glob_filter__glob_snapshots@apple.txt.snap");
+}

--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -70,6 +70,7 @@ use tempfile::TempDir;
 
 mod binary;
 mod delete_pending;
+mod glob_filter;
 mod inline;
 mod test_workspace_source_path;
 mod unreferenced;

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -67,7 +67,8 @@ pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &s
     });
 
     // step 1: collect all matching files
-    let mut matching_files = vec![];
+    let mut all_matching_files = vec![];
+    let mut filtered_files = vec![];
     for file in walker {
         let file = file.unwrap();
         let path = file.path();
@@ -77,6 +78,7 @@ pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &s
         }
 
         glob_found_matches = true;
+        all_matching_files.push(path.to_path_buf());
 
         // if there is a glob filter, skip if it does not match this path
         if !GLOB_FILTER.is_empty() && !GLOB_FILTER.iter().any(|x| x.is_match(stripped_path)) {
@@ -84,12 +86,17 @@ pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &s
             continue;
         }
 
-        matching_files.push(path.to_path_buf());
+        filtered_files.push(path.to_path_buf());
     }
 
     // step 2: sort, determine common prefix and run assertions
-    matching_files.sort();
-    let common_prefix = find_common_prefix(&matching_files);
+    all_matching_files.sort();
+    filtered_files.sort();
+
+    // Use the common prefix from ALL matching files, not just filtered ones
+    // This preserves the original snapshot naming when filtering
+    let common_prefix = find_common_prefix(&all_matching_files);
+    let matching_files = filtered_files;
     for path in &matching_files {
         settings.set_input_file(path);
 


### PR DESCRIPTION
When using `INSTA_GLOB_FILTER`, the common prefix used for snapshot naming should be derived from all files matching the original glob pattern, not just the filtered subset. This ensures that snapshot names retain their original file suffixes (e.g., `@file.txt.snap`) even when only a single file is matched by the filter.

Adds a test case to verify this behavior.

Co-authored-by: Claude <no-reply@anthropic.com>
