### PR TITLE
Release insta 1.43.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
-## Unreleased
+## 1.43.2
 
+- Preserve snapshot names with `INSTA_GLOB_FILTER`. #786
 - Bumped `libc` crate to `0.2.174`, fixing building on musl targets, and increasing the MSRV of
-  `insta` to `1.64.0` (released Sept 2022)
+  `insta` to `1.64.0` (released Sept 2022). #784
+- Fix clippy 1.88 errors. #783
+- Fix source path in snapshots for non-child workspaces. #778
+- Add lifetime to Selector in redaction iterator. #779
 
 ## 1.43.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.43.1"
+version = "1.43.2"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.43.1"
+version = "1.43.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.43.1", path = "../insta", features = [
+insta = { version = "=1.43.2", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.43.1"
+version = "1.43.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
This release includes several fixes and improvements:
- Preserve snapshot names with `INSTA_GLOB_FILTER`.
- Bumped `libc` crate to `0.2.174`, fixing building on musl targets, and increasing the MSRV of `insta` to `1.64.0`.
- Fix clippy 1.88 errors.
- Fix source path in snapshots for non-child workspaces.
- Add lifetime to Selector in redaction iterator.

Co-authored-by: Claude <no-reply@anthropic.com>
