### PR TITLE
Prepare CHANGELOG for 1.43.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## Unreleased
 
-- Fix panics when `cargo metadata` fails to execute or parse (e.g., when cargo is not in PATH or returns invalid output). Now falls back to using the manifest directory as the workspace root. #798 (@adriangb)
-- Changed diff line numbers to 1-based indexing.
-
 ## 1.43.2
 
+- Fix panics when `cargo metadata` fails to execute or parse (e.g., when cargo is not in PATH or returns invalid output). Now falls back to using the manifest directory as the workspace root. #798 (@adriangb)
+- Fix clippy `uninlined_format_args` lint warnings. #801
+- Changed diff line numbers to 1-based indexing. #799
 - Preserve snapshot names with `INSTA_GLOB_FILTER`. #786
 - Bumped `libc` crate to `0.2.174`, fixing building on musl targets, and increasing the MSRV of
   `insta` to `1.64.0` (released Sept 2022). #784


### PR DESCRIPTION
## Summary
- Updates CHANGELOG.md to move all unreleased changes into the 1.43.2 section
- Prepares for tagging version 1.43.2

## Changes included in 1.43.2
- Fix panics when `cargo metadata` fails to execute or parse (#798)
- Fix clippy `uninlined_format_args` lint warnings (#801)  
- Changed diff line numbers to 1-based indexing (#799)
- Preserve snapshot names with `INSTA_GLOB_FILTER` (#786)
- (Plus other changes already listed in the 1.43.2 section)

## Test plan
- [x] CHANGELOG.md updated with all recent changes
- [ ] Ready to tag as 1.43.2 after merge

🤖 Generated with [Claude Code](https://claude.ai/code)