### PR TITLE
Add --disable-nextest-doctest flag and deprecation warning

### DIFF
--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -72,6 +72,7 @@ mod binary;
 mod delete_pending;
 mod glob_filter;
 mod inline;
+mod nextest_doctest;
 mod test_workspace_source_path;
 mod unreferenced;
 mod workspace;

--- a/cargo-insta/tests/functional/nextest_doctest.rs
+++ b/cargo-insta/tests/functional/nextest_doctest.rs
@@ -1,0 +1,183 @@
+use std::process::Stdio;
+
+use crate::TestFiles;
+
+/// Test that nextest with doctests shows a warning
+#[test]
+fn test_nextest_doctest_warning() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_nextest_doctest_warning")
+        .add_file(
+            "src/lib.rs",
+            r#"
+/// This is a function with a doctest
+///
+/// ```
+/// assert_eq!(test_nextest_doctest_warning::add(2, 2), 4);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[test]
+fn test_simple() {
+    insta::assert_snapshot!("test_value", @"test_value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run with nextest and capture stderr to check for warning
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--test-runner", "nextest", "--accept"])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(
+            "warning: insta won't run a separate doctest process when using nextest in the future"
+        ),
+        "Expected warning message not found in stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("Pass `--disable-nextest-doctest` to update to this behavior now and silence this warning"),
+        "Expected flag suggestion not found in stderr:\n{stderr}"
+    );
+}
+
+/// Test that nextest with --disable-nextest-doctest flag doesn't show warning
+#[test]
+fn test_nextest_doctest_flag_no_warning() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_nextest_doctest_flag")
+        .add_file(
+            "src/lib.rs",
+            r#"
+/// This is a function with a doctest
+///
+/// ```
+/// assert_eq!(test_nextest_doctest_flag::add(2, 2), 4);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[test]
+fn test_simple() {
+    insta::assert_snapshot!("test_value", @"test_value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run with nextest and the flag, capture stderr to verify no warning
+    let output = test_project
+        .insta_cmd()
+        .args([
+            "test",
+            "--test-runner",
+            "nextest",
+            "--disable-nextest-doctest",
+            "--accept",
+        ])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning: insta won't run a separate doctest process"),
+        "Warning message should not appear when flag is used:\n{stderr}"
+    );
+}
+
+/// Test that no warning appears when there are no doctests
+#[test]
+fn test_nextest_no_doctests_no_warning() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_nextest_no_doctests")
+        .add_file(
+            "src/lib.rs",
+            r#"
+// No doctests here
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[test]
+fn test_simple() {
+    insta::assert_snapshot!("test_value", @"test_value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run with nextest when there are no doctests
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--test-runner", "nextest", "--accept"])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning: insta won't run a separate doctest process"),
+        "Warning should not appear when there are no doctests:\n{stderr}"
+    );
+}
+
+/// Test that cargo-test doesn't show the warning even with doctests
+#[test]
+fn test_cargo_test_no_warning() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_cargo_test_no_warning")
+        .add_file(
+            "src/lib.rs",
+            r#"
+/// This is a function with a doctest
+///
+/// ```
+/// assert_eq!(test_cargo_test_no_warning::add(2, 2), 4);
+/// ```
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+#[test]
+fn test_simple() {
+    insta::assert_snapshot!("test_value", @"test_value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run with cargo-test (should not show warning)
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--test-runner", "cargo-test", "--accept"])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("warning: insta won't run a separate doctest process"),
+        "Warning should not appear with cargo-test runner:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a `--disable-nextest-doctest` flag to disable running separate doctests when using nextest
- Shows a deprecation warning when nextest is used with doctests, informing users that insta won't run a separate doctest process when using nextest in the future
- Users can pass `--disable-nextest-doctest` to opt into the new behavior now and silence the warning

## Changes

1. **Added `--disable-nextest-doctest` flag** to `TestCommand` struct
2. **Added `has_doctests()` function** that checks if any packages contain doctests by scanning for `/// ```` or `//! ```` patterns in source files
3. **Added deprecation warning** that appears when:
   - Using nextest test runner
   - Doctests are present in the codebase
   - The `--disable-nextest-doctest` flag is not set
4. **Added comprehensive functional tests** covering all scenarios:
   - Warning appears with nextest when doctests exist
   - Warning is suppressed with the flag
   - No warning when no doctests exist
   - No warning with cargo-test runner

## Test Plan

✅ All existing tests pass
✅ Added 4 new functional tests that verify the behavior
✅ Manually tested with `cargo run --package cargo-insta -- test --test-runner nextest`
✅ Code passes clippy and rustfmt checks

🤖 Generated with [Claude Code](https://claude.ai/code)