### PR TITLE
insta: Cargo: allow globset version up to 0.4.16

### DIFF
--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -50,7 +50,7 @@ pest = { version = "2.1.3", optional = true }
 pest_derive = { version = "2.1.0", optional = true }
 ron = { version = "0.7.1", optional = true }
 toml = { version = "0.5.7", optional = true }
-globset = { version = "0.4.6", optional = true }
+globset = { version = ">= 0.4.6, < 0.4.17", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }
 regex = { version = "1.6.0", default-features = false, optional = true, features = [


### PR DESCRIPTION
## Summary

[globset v0.4.17](https://github.com/BurntSushi/ripgrep/releases/tag/globset-0.4.17) changed its rust edition from 2021 to 2024. As insta is currently on edition 2021 ensure to use globset versions <0.4.17.

## References
- https://github.com/BurntSushi/ripgrep/commit/a60e62d9ac559b1468d4dd27b80a7b662a600e0c
- https://github.com/BurntSushi/ripgrep/pull/3149