### PR TITLE
Add LLM-friendly non-interactive snapshot management

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -622,8 +622,8 @@ fn review_snapshots(
     let mut show_diff = true;
     let mut apply_to_all: Option<Operation> = None;
 
-    // Non-interactive mode: if we have a filter and no TTY, just show diffs
-    // This applies to review (op is None) and reject with specific snapshots
+    // Non-interactive mode: if we have a filter and no TTY, just show diffs.
+    // Accept doesn't need display (it just accepts), but review and reject should show what they're affecting.
     let non_interactive_display = snapshot_filter.is_some()
         && !term.is_term()
         && (op.is_none() || matches!(op, Some(Operation::Reject)));


### PR DESCRIPTION
> From Claude

## Summary

Enhance `cargo-insta` for use in non-TTY environments (LLMs, CI pipelines, scripts) by adding non-interactive modes for snapshot review and management.

## Changes

### Non-Interactive Review Mode
- `cargo insta review --snapshot <path>` now works without a TTY
- Shows the snapshot diff in a read-only mode
- Provides instructions for accepting/rejecting

### Non-Interactive Reject Mode  
- `cargo insta reject --snapshot <path>` now works without a TTY
- Shows the diff before rejecting (so users can verify what they're rejecting)
- Actually performs the rejection

### Enhanced `pending-snapshots` Output
- Now shows helpful usage instructions instead of just paths
- Provides example commands with actual snapshot paths
- Uses workspace-relative paths for better readability

### Helper Function
- Extracted `format_snapshot_key()` to eliminate code duplication
- Consistently uses workspace-relative paths throughout

### Improved Error Messages
- Updated TTY error message to guide users to non-interactive alternatives
- Mentions all available non-interactive commands

## Examples

**Before (without TTY):**
```bash
$ cargo insta review
error: Interactive review requires a terminal. Use `cargo insta accept` or `cargo insta reject`...
```

**After (without TTY):**
```bash
$ cargo insta pending-snapshots
Pending snapshots:
  src/lib.rs:42
  src/snapshots/test__example.snap

To review a snapshot: cargo insta review --snapshot 'src/lib.rs:42'
To accept a snapshot: cargo insta accept --snapshot 'src/lib.rs:42'
To reject a snapshot: cargo insta reject --snapshot 'src/lib.rs:42'

$ cargo insta review --snapshot 'src/lib.rs:42'
Snapshot: src/lib.rs:42 (inline):
  Package: example@0.1.0

[... shows full diff ...]

To accept: cargo insta accept --snapshot 'src/lib.rs:42'
To reject: cargo insta reject --snapshot 'src/lib.rs:42'

$ cargo insta accept --snapshot 'src/lib.rs:42'
insta review finished
accepted:
  src/lib.rs:42 (inline)
```

## Use Cases

This is particularly useful for:
- **LLM/AI coding assistants** - Can now review and manage snapshots programmatically
- **CI/CD pipelines** - Scripts can review specific snapshots without interactive prompts
- **Automated workflows** - Tools can inspect snapshot diffs before deciding to accept/reject

## Testing

- ✅ All existing tests pass (62 tests)
- ✅ All lints pass (`pre-commit run --all-files`)
- ✅ Manually tested non-interactive review/reject workflows
- ✅ Verified workspace-relative paths work correctly

## Backward Compatibility

- All changes are additive - existing behavior unchanged
- Interactive mode still works as before
- JSON output from `pending-snapshots --as-json` maintains absolute paths for machine consumption
- Human-readable output uses relative paths for better UX