### PR TITLE
Fix backward compatibility for --test-runner-fallback true syntax

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -222,7 +222,6 @@ struct TestCommand {
         long = "test-runner-fallback",
         num_args(0..=1),
         default_missing_value = "true",
-        require_equals = true,
         overrides_with = "_no_test_runner_fallback"
     )]
     test_runner_fallback: Option<bool>,

--- a/cargo-insta/tests/functional/test_runner_fallback.rs
+++ b/cargo-insta/tests/functional/test_runner_fallback.rs
@@ -94,6 +94,37 @@ fn test_snapshot() {
     );
 }
 
+/// Test that --test-runner-fallback true (with space) enables fallback (backward compatibility)
+#[test]
+fn test_runner_fallback_space_true() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_runner_fallback_space_true")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_snapshot() {
+    insta::assert_snapshot!("value", @"value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run with --test-runner-fallback true (space syntax, backward compatibility)
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--test-runner-fallback", "true"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Test should succeed with --test-runner-fallback true\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Test that --no-test-runner-fallback disables fallback
 #[test]
 fn test_no_test_runner_fallback_flag() {


### PR DESCRIPTION
This is a small fix to PR #811 which introduced `--test-runner-fallback` and `--no-test-runner-fallback` flags.

## Issue

The previous PR added `require_equals = true` to the clap argument configuration, which broke backward compatibility with the space syntax:

- ❌ `--test-runner-fallback true` (broke in #811)
- ✅ `--test-runner-fallback=true` (still worked)

The old implementation accepted both syntaxes, so this was a regression.

## Fix

Removed `require_equals = true` from the argument configuration to restore backward compatibility. This allows all syntaxes to work:

**New ergonomic syntax:**
- `--test-runner-fallback` (no value)
- `--no-test-runner-fallback`

**Backward compatible syntax:**
- `--test-runner-fallback true` (with space) ✅ now fixed
- `--test-runner-fallback=true` (with equals)
- `--test-runner-fallback false`
- `--test-runner-fallback=false`

## Testing

- Added new test `test_runner_fallback_space_true` to cover the space syntax
- All 7 test_runner_fallback tests pass

## Changes

- Removed `require_equals = true` from `cargo-insta/src/cli.rs`
- Added test for space syntax in `cargo-insta/tests/functional/test_runner_fallback.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)