### PR TITLE
Support `-r` shorthand for `--release`, for compatibility with `cargo test`

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -156,7 +156,7 @@ struct TestRunnerOptions {
     #[arg(short = 'j', long)]
     jobs: Option<usize>,
     /// Build artifacts in release mode, with optimizations
-    #[arg(long)]
+    #[arg(short = 'r', long)]
     release: bool,
     /// Build artifacts with the specified profile
     #[arg(long)]


### PR DESCRIPTION
This makes it easier to move from `cargo test -r ...` to `cargo insta test -r ...`.
