### PR TITLE
Add --dnd alias for --disable-nextest-doctest flag

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -238,7 +238,7 @@ struct TestCommand {
     #[arg(long, hide = true)]
     no_force_pass: bool,
     /// Disable running doctests when using nextest test runner
-    #[arg(long)]
+    #[arg(long, alias = "dnd")]
     disable_nextest_doctest: bool,
     #[command(flatten)]
     target_args: TargetArgs,
@@ -897,7 +897,7 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
         if has_doctests(&loc.packages) {
             eprintln!(
                 "{}: insta won't run a separate doctest process when using nextest in the future. \
-                 Pass `--disable-nextest-doctest` to update to this behavior now and silence this warning.",
+                 Pass `--disable-nextest-doctest` (or `--dnd`) to update to this behavior now and silence this warning.",
                 style("warning").bold().yellow()
             );
         }


### PR DESCRIPTION
## Summary

Adds a shorter `--dnd` alias for the `--disable-nextest-doctest` flag to make it easier to silence the deprecation warning during the transition period.

This addresses the request from @ilyagr in #803:
> It seems like people will pass this flag often to avoid the deprecation warning. Perhaps give it a short version, e.g. `-D`?

After discussion, we agreed on `--dnd` as the alias.

## Changes

- Add `alias = "dnd"` to the `disable_nextest_doctest` CLI argument
- Update deprecation warning message to mention the `--dnd` alias: `Pass '--disable-nextest-doctest' (or '--dnd') to update to this behavior now and silence this warning.`
- Add test `test_nextest_doctest_dnd_alias_no_warning()` to verify the alias works correctly

## Test plan

- [x] All existing tests pass (5/5 in nextest_doctest module)
- [x] New test verifies `--dnd` alias works correctly
- [x] Lints pass (cargo fmt, cargo clippy)
- [x] Manual verification: `cargo insta test --test-runner nextest --dnd` works as expected

## Usage

Both forms work identically:
```bash
cargo insta test --test-runner nextest --disable-nextest-doctest
cargo insta test --test-runner nextest --dnd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)