### PR TITLE
Prepare release 1.44.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## Unreleased
 
+## 1.44.1
+
+- Add `--dnd` alias for `--disable-nextest-doctest` flag to make it easier to silence the deprecation warning. #822
+- Update cargo-dist to 0.30.2 and fix Windows runner to use windows-2022. #821
+
 ## 1.44.0
 
 - Added non-interactive snapshot review and reject modes for use in non-TTY environments

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.44.0"
+version = "1.44.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.0"
+version = "1.44.1"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.44.0"
+version = "1.44.1"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.44.0", path = "../insta", features = [
+insta = { version = "=1.44.1", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.44.0"
+version = "1.44.1"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
## Summary

Prepare for the 1.44.1 patch release with two changes since 1.44.0.

## Changes

- Add `--dnd` alias for `--disable-nextest-doctest` flag to make it easier to silence the deprecation warning (#822)
- Update cargo-dist to 0.30.2 and fix Windows runner to use windows-2022 (#821)

## Version Updates

- Bump version to 1.44.1 in `insta/Cargo.toml` and `cargo-insta/Cargo.toml`
- Update CHANGELOG.md with release notes
- Update Cargo.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)