### PR TITLE
Fix functional tests failing under nextest

### DIFF
--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -216,6 +216,9 @@ impl TestProject {
         cmd.env_remove("CARGO_TERM_COLOR");
         cmd.env_remove("CLICOLOR_FORCE");
         cmd.env_remove("RUSTDOCFLAGS");
+        // Remove NEXTEST_RUN_ID so that each cargo insta test invocation gets
+        // its own unique run_id, rather than all sharing the outer nextest's ID
+        cmd.env_remove("NEXTEST_RUN_ID");
     }
 
     fn insta_cmd(&self) -> Command {


### PR DESCRIPTION
## Summary

- Fix `test_pending_snapshot_deletion` failing when run under nextest
- Clear `NEXTEST_RUN_ID` environment variable in functional test setup

When running functional tests under nextest, the `NEXTEST_RUN_ID` environment variable was inherited by child `cargo insta test` invocations. Since insta uses this variable as the `RUN_ID` for pending snapshots (see `insta/src/snapshot.rs:18`), all pending inline snapshots ended up sharing the same run_id.

This broke the cleanup mechanism in `load_batch()` which keeps all entries with the last run_id. When a test passed and wrote a NULL entry to mark the snapshot as clean, the previous failing entry was also kept (same run_id), preventing the `.pending-snap` file from being deleted.

## Test plan

- [x] `cargo test --package cargo-insta` passes
- [x] `cargo nextest run --package cargo-insta` passes (previously failed on `test_pending_snapshot_deletion`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)