### PR TITLE
Prepare release 1.44.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## Unreleased
 
+## 1.44.2
+
+- Fix a rare backward compatibility issue where inline snapshots using an uncommon legacy format (single-line content stored in multiline raw strings) could fail to match after 1.44.0. #830
+- Handle merge conflicts in snapshot files gracefully. When a snapshot file contains git merge conflict markers, insta now detects them and treats the snapshot as missing, allowing tests to continue and create a new pending snapshot for review. #829
+- Skip nextest_doctest tests when cargo-nextest is not installed. #826
+- Fix functional tests failing under nextest due to inherited `NEXTEST_RUN_ID` environment variable. #824
+
 ## 1.44.1
 
 - Add `--dnd` alias for `--disable-nextest-doctest` flag to make it easier to silence the deprecation warning. #822

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.44.1"
+version = "1.44.2"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.1"
+version = "1.44.2"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.44.1"
+version = "1.44.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.44.1", path = "../insta", features = [
+insta = { version = "=1.44.2", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.44.1"
+version = "1.44.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
## Summary

Prepare for the 1.44.2 patch release with four changes since 1.44.1.

## Changes

- Fix backward compatibility for legacy inline snapshot format. Snapshots using single-line content in multiline raw strings now correctly match again. (#830)
- Handle merge conflicts in snapshot files gracefully. When a snapshot file contains git merge conflict markers, insta now detects them and treats the snapshot as missing, allowing tests to continue and create a new pending snapshot for review. (#829)
- Skip nextest_doctest tests when cargo-nextest is not installed. (#826)
- Fix functional tests failing under nextest due to inherited `NEXTEST_RUN_ID` environment variable. (#824)

## Version Updates

- Bump version to 1.44.2 in `insta/Cargo.toml` and `cargo-insta/Cargo.toml`
- Update CHANGELOG.md with release notes
- Update Cargo.lock

## Test plan

- [x] All tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)