### PR TITLE
Prepare release 1.44.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
-## Unreleased
+## 1.44.3
+
+- Fix a regression in 1.44.2 where merge conflict detection was too aggressive, incorrectly flagging snapshot content containing `======` or similar patterns as conflicts. #832
+- Fix a regression in 1.42.2 where inline snapshot updates would corrupt the file when code preceded the macro (e.g., `let output = assert_snapshot!(...)`). #833
 
 ## 1.44.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.44.2"
+version = "1.44.3"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.44.2"
+version = "1.44.3"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.44.2"
+version = "1.44.3"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.44.2", path = "../insta", features = [
+insta = { version = "=1.44.3", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.44.2"
+version = "1.44.3"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
## Summary

- Fix regression in 1.44.2: merge conflict detection too aggressive (#832)
- Fix regression in 1.42.2: inline snapshot corruption with code before macro (#833)

🤖 Generated with [Claude Code](https://claude.com/claude-code)