### PR TITLE
Collect warnings from tests for display after run

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -884,6 +884,12 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
     let (mut proc, snapshot_ref_file, prevents_doc_run) =
         prepare_test_runner(&cmd, test_runner, color, &[], None, &loc)?;
 
+    // Set up warnings file for collecting warnings from test processes.
+    // This is necessary because test runners like nextest suppress stdout/stderr
+    // from passing tests by default.
+    let warnings_file = env::temp_dir().join(format!("insta-warnings-{}", Uuid::new_v4()));
+    proc.env("INSTA_WARNINGS_FILE", &warnings_file);
+
     if let Some(workspace_root) = &cmd.target_args.workspace_root {
         proc.current_dir(workspace_root);
     }
@@ -921,7 +927,22 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
             snapshot_ref_file.as_deref(),
             &loc,
         )?;
+        // Use the same warnings file for doctests
+        proc.env("INSTA_WARNINGS_FILE", &warnings_file);
         success = success && proc.status()?.success();
+    }
+
+    // Display any warnings collected during tests (deduplicated)
+    if warnings_file.exists() {
+        if let Ok(contents) = fs::read_to_string(&warnings_file) {
+            let mut seen = std::collections::BTreeSet::new();
+            for line in contents.lines().map(str::trim).filter(|l| !l.is_empty()) {
+                if seen.insert(line.to_owned()) {
+                    eprintln!("{}", line);
+                }
+            }
+        }
+        fs::remove_file(&warnings_file).ok();
     }
 
     if !success && cmd.review {

--- a/cargo-insta/tests/functional/nextest_doctest.rs
+++ b/cargo-insta/tests/functional/nextest_doctest.rs
@@ -303,3 +303,68 @@ fn test_simple() {
         "Warning message should not appear when config is set:\n{stderr}"
     );
 }
+
+/// Test that legacy format deprecation warnings are visible when running with nextest.
+///
+/// Nextest suppresses stdout/stderr from passing tests by default. To ensure
+/// deprecation warnings are visible, cargo-insta collects warnings via
+/// `INSTA_WARNINGS_FILE` and displays them after tests complete.
+#[test]
+fn test_nextest_legacy_format_warning_visible() {
+    if !nextest_available() {
+        eprintln!("Skipping test: cargo-nextest not installed");
+        return;
+    }
+
+    // Create a project with a legacy format inline snapshot (single-line content
+    // stored in multiline format). This triggers the "existing value is in a
+    // legacy format" warning.
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_nextest_legacy_warning")
+        .add_file(
+            "src/lib.rs",
+            r#####"
+#[test]
+fn test_legacy_format() {
+    insta::assert_snapshot!(get_value(), @r"
+    single line content
+    ");
+}
+
+fn get_value() -> &'static str {
+    "single line content"
+}
+"#####
+                .to_string(),
+        )
+        .create_project();
+
+    // Run with nextest and capture both stdout and stderr.
+    // cargo-insta now collects warnings via INSTA_WARNINGS_FILE and displays
+    // them after tests complete, so we don't need NEXTEST_SUCCESS_OUTPUT.
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--test-runner", "nextest", "--check", "--dnd"])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .output()
+        .unwrap();
+
+    // Test should pass (legacy format still matches)
+    assert!(
+        output.status.success(),
+        "Test should pass with legacy format. Stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The legacy format warning should be visible in the output
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let combined = format!("{stderr}\n{stdout}");
+
+    assert!(
+        combined.contains("existing value is in a legacy format"),
+        "Legacy format warning not found in nextest output.\n\
+         Stderr:\n{stderr}\n\nStdout:\n{stdout}"
+    );
+}

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -574,6 +574,16 @@ pub fn memoize_snapshot_file(snapshot_file: &Path) {
     }
 }
 
+/// Appends a warning to the warnings file for cargo-insta to display after tests.
+/// Best-effort: does nothing if `INSTA_WARNINGS_FILE` is not set or IO fails.
+pub fn memoize_warning(message: &str) {
+    if let Ok(path) = env::var("INSTA_WARNINGS_FILE") {
+        if let Ok(mut f) = fs::OpenOptions::new().append(true).create(true).open(path) {
+            let _ = writeln!(f, "{}", message);
+        }
+    }
+}
+
 fn resolve<'a>(value: &'a Content, path: &[&str]) -> Option<&'a Content> {
     path.iter()
         .try_fold(value, |node, segment| match node.resolve_inner() {


### PR DESCRIPTION
Nextest suppresses stdout/stderr from passing tests by default. To ensure deprecation warnings are visible, cargo-insta collects warnings via a temporary file and displays them after tests complete.