### PR TITLE
Skip non-insta snapshot files in unreferenced detection

### DIFF
--- a/cargo-insta/tests/functional/unreferenced.rs
+++ b/cargo-insta/tests/functional/unreferenced.rs
@@ -347,3 +347,158 @@ Unused snapshot
         "Unreferenced snapshot file should have been deleted"
     );
 }
+
+/// Test that non-insta snapshot files (e.g., vitest, jest) are not flagged as
+/// unreferenced insta snapshots. This addresses issue #845 where projects using
+/// both insta and vitest would have vitest's .snap files incorrectly flagged.
+#[test]
+fn test_unreferenced_ignores_non_insta_snapshots() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_non_insta_snap")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_snapshot() {
+    insta::assert_snapshot!("Hello, world!");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run tests to create the insta snapshot
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Add a vitest-format snapshot file (non-insta)
+    let vitest_snapshot_path = test_project
+        .workspace_dir
+        .join("src/snapshots/example.test.js.snap");
+    std::fs::write(
+        &vitest_snapshot_path,
+        r#"// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`example test 1`] = `"Hello from vitest"`;
+"#,
+    )
+    .unwrap();
+
+    // Add a jest-format snapshot file (non-insta)
+    let jest_snapshot_path = test_project
+        .workspace_dir
+        .join("src/snapshots/another.test.js.snap");
+    std::fs::write(
+        &jest_snapshot_path,
+        r#"// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`another test 1`] = `"Hello from jest"`;
+"#,
+    )
+    .unwrap();
+
+    // Run with --unreferenced=delete
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--unreferenced=delete", "--", "--nocapture"])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // The vitest and jest snapshots should NOT be deleted
+    assert!(
+        vitest_snapshot_path.exists(),
+        "Vitest snapshot should be preserved (not an insta snapshot)"
+    );
+    assert!(
+        jest_snapshot_path.exists(),
+        "Jest snapshot should be preserved (not an insta snapshot)"
+    );
+
+    // The insta snapshot should still exist
+    let insta_snapshot_path = test_project
+        .workspace_dir
+        .join("src/snapshots/test_non_insta_snap__snapshot.snap");
+    assert!(
+        insta_snapshot_path.exists(),
+        "Insta snapshot should still exist"
+    );
+
+    // Verify the output mentions "no unreferenced snapshots found"
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no unreferenced snapshots found"),
+        "Should report no unreferenced snapshots since non-insta files are ignored. Got: {stderr}"
+    );
+}
+
+/// Test that --unreferenced=reject does not fail on non-insta snapshot files.
+#[test]
+fn test_unreferenced_reject_ignores_non_insta_snapshots() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_reject_non_insta")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_snapshot() {
+    insta::assert_snapshot!("Hello, world!");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Run tests to create the insta snapshot
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    // Add a vitest-format snapshot file (non-insta)
+    let vitest_snapshot_path = test_project
+        .workspace_dir
+        .join("src/snapshots/component.test.ts.snap");
+    std::fs::write(
+        &vitest_snapshot_path,
+        r#"// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Component renders correctly 1`] = `
+<div>
+  <span>Hello</span>
+</div>
+`;
+"#,
+    )
+    .unwrap();
+
+    // Run with --unreferenced=reject - should NOT fail because vitest file is ignored
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--unreferenced=reject", "--", "--nocapture"])
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    // Should succeed - no insta snapshots are unreferenced
+    assert!(
+        output.status.success(),
+        "Should succeed because vitest snapshots are not considered insta snapshots"
+    );
+
+    // Vitest snapshot should still exist
+    assert!(
+        vitest_snapshot_path.exists(),
+        "Vitest snapshot should be preserved"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `is_likely_insta_snapshot()` function that reads only 16 bytes to check for `---\nsource:` prefix
- Filters unreferenced snapshot detection to skip files that don't match insta's format
- Adds functional tests for vitest and jest snapshot file preservation

This allows projects using both insta and other snapshot testing tools (like vitest or jest) to use `--unreferenced=reject` without false positives.

Fixes #845

## Test plan

- [x] Added `test_unreferenced_ignores_non_insta_snapshots` - verifies vitest/jest `.snap` files are not deleted by `--unreferenced=delete`
- [x] Added `test_unreferenced_reject_ignores_non_insta_snapshots` - verifies `--unreferenced=reject` doesn't fail on non-insta `.snap` files
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)