### PR TITLE
Release 1.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.45.1
+
+- Fix backward compatibility with TOML format produced by insta < 1.45.0. #849 (@chitoku-k)
+
 ## 1.45.0
 
 - Add external diff tool support via `INSTA_DIFF_TOOL` environment variable. When set, insta uses the specified tool (e.g., `delta`, `difftastic`) to display snapshot diffs instead of the built-in diff. The tool is invoked as `<tool> <old_file> <new_file>`. #844

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.45.0"
+version = "1.45.1"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.45.0"
+version = "1.45.1"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.45.0", path = "../insta", features = [
+insta = { version = "=1.45.1", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.45.0"
+version = "1.45.1"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
## Summary

- Bumps version to 1.45.1
- Updates CHANGELOG with the fix from #849

## Changes

- Fix backward compatibility with TOML format produced by insta < 1.45.0. #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)