### PR TITLE
feat: Support YAML literal blocks for multiline strings

### DIFF
--- a/insta/src/content/yaml/mod.rs
+++ b/insta/src/content/yaml/mod.rs
@@ -49,6 +49,9 @@ pub fn to_string(content: &Content) -> String {
 
     let mut buf = String::new();
     let mut emitter = crate::content::yaml::vendored::emitter::YamlEmitter::new(&mut buf);
+    if std::env::var("INSTA_YAML_BLOCK_STYLE").as_deref() == Ok("1") {
+        emitter.use_literal_blocks(true);
+    }
     emitter.dump(&yaml_blob).unwrap();
 
     if !buf.ends_with('\n') {


### PR DESCRIPTION
Thanks for the project!

This PR adds opt-in support for YAML literal blocks for multiline strings in snapshot metadata fields like `description` and `expression`. Trailing newlines are preserved via chomping indicators (`|-`, `|`, `|+`).

Set `INSTA_YAML_BLOCK_STYLE=1` to enable.

Before:

```yaml
expression: "fn add(a: i32, b: i32) -> i32 {\n    a + b\n}"
```

After:

```yaml
expression: |-
  fn add(a: i32, b: i32) -> i32 {
      a + b
  }
```

I noticed the YAML lib is vendored and assumed extending it was acceptable - please let me know if you'd prefer a different approach.

Closes #782