### PR TITLE
Fix docs for test.runner_fallback config key

### DIFF
--- a/cargo-insta/tests/functional/test_runner_fallback.rs
+++ b/cargo-insta/tests/functional/test_runner_fallback.rs
@@ -1,5 +1,71 @@
 use super::*;
 
+/// Test that test_runner_fallback config file setting enables fallback
+/// when nextest is unavailable.
+///
+/// This test creates a fake cargo wrapper that pretends nextest is not installed,
+/// then verifies that the config file's `test_runner_fallback: true` causes
+/// cargo-insta to fall back to `cargo test`.
+#[test]
+#[cfg(unix)]
+fn test_runner_fallback_config_file() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Stdio;
+
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_runner_fallback_config")
+        .add_file(
+            "insta.yaml",
+            r#"
+test:
+  runner: nextest
+  runner_fallback: true
+"#
+            .to_string(),
+        )
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_snapshot() {
+    insta::assert_snapshot!("value", @"value");
+}
+"#
+            .to_string(),
+        )
+        .add_file(
+            "fake_cargo.sh",
+            r#"#!/bin/bash
+if [ "$1" = "nextest" ]; then
+    echo "error: no such command: nextest" >&2
+    exit 1
+fi
+exec cargo "$@"
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // Make the fake cargo executable and get path
+    let fake_cargo_path = test_project.workspace_dir.join("fake_cargo.sh");
+    std::fs::set_permissions(&fake_cargo_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Run with fake cargo - should fall back to cargo test because config says so
+    let output = test_project
+        .insta_cmd()
+        .args(["test"])
+        .env("CARGO", &fake_cargo_path)
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "Test should succeed with config file test_runner_fallback: true\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 /// Test that --test-runner-fallback flag (without value) enables fallback
 #[test]
 fn test_runner_fallback_flag_enables() {

--- a/insta/src/env.rs
+++ b/insta/src/env.rs
@@ -296,7 +296,7 @@ impl ToolConfig {
                     .unwrap_or(false),
                 Ok("1") => true,
                 Ok("0") => false,
-                _ => return Err(Error::Env("INSTA_RUNNER_FALLBACK")),
+                _ => return Err(Error::Env("INSTA_TEST_RUNNER_FALLBACK")),
             },
             #[cfg(feature = "_cargo_insta_internal")]
             test_unreferenced: {

--- a/insta/src/lib.rs
+++ b/insta/src/lib.rs
@@ -233,7 +233,7 @@
 //!   runner: "auto" | "cargo-test" | "nextest"
 //!   # whether to fallback to `cargo-test` if `nextest` is not available,
 //!   # also set by INSTA_TEST_RUNNER_FALLBACK, default false
-//!   test_runner_fallback: true/false
+//!   runner_fallback: true/false
 //!   # disable running doctests separately when using nextest
 //!   disable_nextest_doctest: true/false
 //!   # automatically assume --review was passed to cargo insta test


### PR DESCRIPTION
## Summary

The documentation showed `test_runner_fallback` as the config key, but the code expected `runner_fallback`. This is consistent with other keys under `test:`:

```yaml
test:
  runner: nextest          # not test_runner
  runner_fallback: true    # not test_runner_fallback (was documented wrong)
  unreferenced: warn       # not test_unreferenced
  auto_review: true        # not test_auto_review
```

## Changes

- Fix documentation to show correct key: `runner_fallback`
- Add integration test verifying config file setting works
- Fix typo in error message (`INSTA_RUNNER_FALLBACK` → `INSTA_TEST_RUNNER_FALLBACK`)

## Example

```yaml
# .config/insta.yaml
test:
  runner: nextest
  runner_fallback: true  # this is the correct key
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)