### PR TITLE
Remove globset version cap

### DIFF
--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -55,7 +55,7 @@ toml_edit = { version = "0.23.0", optional = true, features = [
   "display",
 ] }
 toml_writer = { version = "1", optional = true }
-globset = { version = ">= 0.4.6, < 0.4.17", optional = true }
+globset = { version = "0.4.6", optional = true }
 walkdir = { version = "2.3.1", optional = true }
 similar = { version = "2.1.0", features = ["inline"] }
 regex = { version = "1.6.0", default-features = false, optional = true, features = [


### PR DESCRIPTION
## Summary

- Remove `< 0.4.17` upper bound on globset dependency
- Lockfile stays pinned to 0.4.9, so existing users unaffected
- Users on Rust 1.84+ can use MSRV-aware resolver if they update

Closes #863

> _This was written by Claude Code on behalf of @max-sixty_