### PR TITLE
Release 1.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.46.2
+
+- Fix inline snapshot corruption with carriage returns. The `leading_space()` function incorrectly treated `\r` as indentation, causing carriage returns to be stripped from snapshot content. #866
+- Remove `< 0.4.17` upper bound on globset dependency. #864
+
 ## 1.46.1
 
 - Fix inline snapshot corruption when multiple snapshots appear inside `with_settings!` macro. #858

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.46.1"
+version = "1.46.2"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.1"
+version = "1.46.2"
 dependencies = [
  "clap",
  "console",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.46.1"
+version = "1.46.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.65.0"
 
 [dependencies]
-insta = { version = "=1.46.1", path = "../insta", features = [
+insta = { version = "=1.46.2", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.46.1"
+version = "1.46.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
## Summary

- Fix inline snapshot corruption with carriage returns. #866
- Remove globset version cap. #864

> _This was written by Claude Code on behalf of @max-sixty_