### PR TITLE
Sort sequences in `sort_maps` to fix non-deterministic `HashSet` snapshots

### DIFF
--- a/insta/src/settings.rs
+++ b/insta/src/settings.rs
@@ -207,7 +207,11 @@ impl Settings {
         Rc::make_mut(&mut self.inner)
     }
 
-    /// Enables forceful sorting of maps before serialization.
+    /// Enables forceful sorting of maps and sequences before serialization.
+    ///
+    /// This is particularly useful for ensuring deterministic snapshots of
+    /// non-ordered collections like [`HashMap`](std::collections::HashMap) and
+    /// [`HashSet`](std::collections::HashSet).
     ///
     /// Note that this only applies to snapshots that undergo serialization
     /// (eg: does not work for [`assert_debug_snapshot!`](crate::assert_debug_snapshot!)).
@@ -217,7 +221,7 @@ impl Settings {
         self._private_inner_mut().sort_maps = value;
     }
 
-    /// Returns the current value for map sorting.
+    /// Returns the current value for map and sequence sorting.
     pub fn sort_maps(&self) -> bool {
         self.inner.sort_maps
     }

--- a/insta/tests/test_settings.rs
+++ b/insta/tests/test_settings.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "json")]
+use insta::assert_json_snapshot;
 #[cfg(feature = "yaml")]
 use insta::assert_yaml_snapshot;
 use similar_asserts::assert_eq;
@@ -125,6 +127,33 @@ fn test_snapshot_with_description_and_info() {
     };
     with_settings!({description => "The snapshot is four integers", info => &info}, {
         assert_debug_snapshot!(vec![1, 2, 3, 4])
+    });
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn test_sort_maps_sorts_hashset() {
+    with_settings!({sort_maps => true}, {
+        assert_json_snapshot!(
+            (
+                std::collections::HashSet::from([2, 1, 3]),
+                std::collections::HashMap::from([("one", 1), ("two", 2), ("three", 3)]),
+            ),
+            @r###"
+        [
+          [
+            1,
+            2,
+            3
+          ],
+          {
+            "one": 1,
+            "three": 3,
+            "two": 2
+          }
+        ]
+        "###
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

- `sort_maps` only sorted `Content::Map`, but `HashSet` serializes as `Content::Seq` via serde, leaving snapshot output non-deterministic across recompilations
- Extend `sort_maps()` to also sort `Content::Seq` items using the same key-based comparison
- Extract shared `cmp_as_key` helper to deduplicate comparison logic between Map and Seq sorting
- Update `set_sort_maps` / `sort_maps` doc comments to reflect the expanded scope

Closes #211

## Test plan

- [x] Added `test_sort_maps_sorts_hashset` verifying both `HashSet` and `HashMap` produce deterministic sorted output
- [x] All existing tests pass with `--all-features`

> _This was written by Claude Code on behalf of max-sixty_