### PR TITLE
Improve TOML serialization error message for unsupported types

### DIFF
--- a/insta/src/serialization.rs
+++ b/insta/src/serialization.rs
@@ -171,7 +171,13 @@ pub fn serialize_content(mut content: Content, format: SerializationFormat) -> S
                 }
             }
 
-            let mut dm = toml_edit::ser::to_document(&content).unwrap();
+            let mut dm = toml_edit::ser::to_document(&content).unwrap_or_else(|e| {
+                panic!(
+                    "TOML serialization failed: {e}. \
+                     Note: TOML requires the top-level value to be a struct or map. \
+                     Use assert_json_snapshot! or assert_yaml_snapshot! for other types.",
+                )
+            });
             let mut visitor = Pretty { in_value: false };
             visitor.visit_document_mut(&mut dm);
 

--- a/insta/tests/test_toml.rs
+++ b/insta/tests/test_toml.rs
@@ -276,9 +276,19 @@ fn test_toml_empty_struct() {
     assert_toml_snapshot!(Container { empty: Empty {} }, @"[empty]");
 }
 
+/// Top-level sequences are NOT supported by TOML (issue #879)
+#[test]
+#[should_panic(expected = "TOML requires the top-level value to be a struct or map")]
+fn test_toml_top_level_sequence_unsupported() {
+    insta::_macro_support::serialize_value(
+        &vec![1, 2, 3],
+        insta::_macro_support::SerializationFormat::Toml,
+    );
+}
+
 /// Unit structs are NOT supported by TOML - this documents the limitation
 #[test]
-#[should_panic(expected = "UnsupportedType")]
+#[should_panic(expected = "unsupported Marker type")]
 fn test_toml_unit_struct_unsupported() {
     #[derive(Serialize)]
     struct Marker;


### PR DESCRIPTION
## Summary

- Replace bare `.unwrap()` in TOML serialization with an informative panic that shows the original `toml_edit` error and explains TOML's top-level struct/map requirement
- Add test for top-level sequence case (issue #879)
- Update existing unit struct test to match the improved error text

Closes #879. Thanks to @ip1981 for reporting.

**Before:**
```
called `Result::unwrap()` on an `Err` value: UnsupportedType(None)
```

**After (top-level sequence):**
```
TOML serialization failed: unsupported rust type. Note: TOML requires the
top-level value to be a struct or map. Use assert_json_snapshot! or
assert_yaml_snapshot! for other types.
```

**After (unsupported inner type):**
```
TOML serialization failed: unsupported Marker type. Note: TOML requires the
top-level value to be a struct or map. Use assert_json_snapshot! or
assert_yaml_snapshot! for other types.
```

## Test plan

- [x] New `test_toml_top_level_sequence_unsupported` test verifies the error message
- [x] Existing `test_toml_unit_struct_unsupported` updated to match improved text
- [x] All 34 TOML tests pass
- [x] Full test suite passes

> _This was written by Claude Code on behalf of @max-sixty_