### PR TITLE
the test_glob test depends on both glob and json

### DIFF
--- a/insta/tests/test_glob.rs
+++ b/insta/tests/test_glob.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "glob")]
+#![cfg(all(feature = "glob", feature = "json"))]
 
 mod glob_submodule;
 


### PR DESCRIPTION
This makes the command `cargo test --no-default-features --features glob` work