### PR TITLE
Release 1.47.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## 1.47.2
+
+- Restore `Send + Sync` on `Settings`, `Redactions`, and `Redaction` by
+  reverting the `Arc` to `Rc` change from 1.47.0, which was semver-breaking.
+  #873 #874
+- Add `Send + Sync` bounds to `Comparator` trait for consistency with
+  `Arc`-based storage. #872
+- Add compile-time assertion to prevent future auto-trait regressions.
+
 ## 1.47.1
 
 - Revert sorting of sequences in `sort_maps`. The change in 1.47.0 sorted all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.47.1"
+version = "1.47.2"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 dependencies = [
  "clap",
  "console 0.16.0",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.47.1"
+version = "1.47.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.66.0"
 
 [dependencies]
-insta = { version = "=1.47.1", path = "../insta", features = [
+insta = { version = "=1.47.2", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"

--- a/insta/src/comparator.rs
+++ b/insta/src/comparator.rs
@@ -17,7 +17,10 @@ use crate::snapshot::{Snapshot, SnapshotContents, TextSnapshotKind};
 ///
 /// This trait requires `'static` so that implementing structs can be stored in
 /// [`crate::settings::Settings`].
-pub trait Comparator: 'static {
+// TODO: `Send + Sync` is required because `Settings` currently uses `Arc`
+// internally. Consider removing these bounds if `Settings` switches to `Rc`
+// in the next breaking change.
+pub trait Comparator: Send + Sync + 'static {
     /// Returns `true` if the contents of `reference` and `test` match.
     ///
     /// This is the standard comparison used by [`assert_snapshot!`].

--- a/insta/src/redaction.rs
+++ b/insta/src/redaction.rs
@@ -54,7 +54,7 @@ pub enum Redaction {
     /// Static redaction with new content.
     Static(Content),
     /// Redaction with new content.
-    Dynamic(Box<dyn Fn(Content, ContentPath<'_>) -> Content>),
+    Dynamic(Box<dyn Fn(Content, ContentPath<'_>) -> Content + Sync + Send>),
 }
 
 macro_rules! impl_from {
@@ -127,7 +127,7 @@ impl<'a> From<&'a [u8]> for Redaction {
 pub fn dynamic_redaction<I, F>(func: F) -> Redaction
 where
     I: Into<Content>,
-    F: Fn(Content, ContentPath<'_>) -> I + 'static,
+    F: Fn(Content, ContentPath<'_>) -> I + Send + Sync + 'static,
 {
     Redaction::Dynamic(Box::new(move |c, p| func(c, p).into()))
 }

--- a/insta/src/settings.rs
+++ b/insta/src/settings.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::comparator::Comparator;
@@ -23,7 +23,7 @@ thread_local!(static CURRENT_SETTINGS: RefCell<Settings> = RefCell::new(Settings
 #[cfg(feature = "redactions")]
 #[cfg_attr(docsrs, doc(cfg(feature = "redactions")))]
 #[derive(Clone, Default)]
-pub struct Redactions(Vec<(Selector<'static>, Rc<Redaction>)>);
+pub struct Redactions(Vec<(Selector<'static>, Arc<Redaction>)>);
 
 #[cfg(feature = "redactions")]
 impl<'a> From<Vec<(&'a str, Redaction)>> for Redactions {
@@ -31,7 +31,7 @@ impl<'a> From<Vec<(&'a str, Redaction)>> for Redactions {
         Redactions(
             value
                 .into_iter()
-                .map(|x| (Selector::parse(x.0).unwrap().make_static(), Rc::new(x.1)))
+                .map(|x| (Selector::parse(x.0).unwrap().make_static(), Arc::new(x.1)))
                 .collect(),
         )
     }
@@ -188,13 +188,17 @@ impl ActualSettings {
 /// ```
 #[derive(Clone)]
 pub struct Settings {
-    inner: Rc<ActualSettings>,
+    // TODO: consider switching to `Rc` in the next breaking change — `Settings`
+    // are stored in thread-local storage and never cross thread boundaries, so
+    // `Arc` is unnecessary. Removing it would also let us drop the `Send + Sync`
+    // bounds on `Redaction` and `Comparator`.
+    inner: Arc<ActualSettings>,
 }
 
 impl Default for Settings {
     fn default() -> Settings {
         Settings {
-            inner: Rc::new(ActualSettings {
+            inner: Arc::new(ActualSettings {
                 sort_maps: false,
                 snapshot_path: "snapshots".into(),
                 snapshot_suffix: "".into(),
@@ -232,7 +236,7 @@ impl Settings {
     /// Internal helper for macros
     #[doc(hidden)]
     pub fn _private_inner_mut(&mut self) -> &mut ActualSettings {
-        Rc::make_mut(&mut self.inner)
+        Arc::make_mut(&mut self.inner)
     }
 
     /// Enables forceful sorting of maps before serialization.
@@ -435,7 +439,7 @@ impl Settings {
     fn add_redaction_impl(&mut self, selector: &str, replacement: Redaction) {
         self._private_inner_mut().redactions.0.push((
             Selector::parse(selector).unwrap().make_static(),
-            Rc::new(replacement),
+            Arc::new(replacement),
         ));
     }
 
@@ -451,7 +455,7 @@ impl Settings {
     pub fn add_dynamic_redaction<I, F>(&mut self, selector: &str, func: F)
     where
         I: Into<Content>,
-        F: Fn(Content, ContentPath<'_>) -> I + 'static,
+        F: Fn(Content, ContentPath<'_>) -> I + Send + Sync + 'static,
     {
         self.add_redaction(selector, dynamic_redaction(func));
     }
@@ -584,7 +588,7 @@ impl Settings {
     /// ```
     pub fn bind_async<F: Future<Output = T>, T>(&self, future: F) -> impl Future<Output = T> {
         struct BindingFuture<F> {
-            settings: Rc<ActualSettings>,
+            settings: Arc<ActualSettings>,
             future: F,
         }
 
@@ -660,7 +664,7 @@ impl Settings {
 /// This is to ensure tests under async runtimes like `tokio` don't show unexpected results
 #[must_use = "The guard is immediately dropped so binding has no effect. Use `let _guard = ...` to bind it."]
 pub struct SettingsBindDropGuard(
-    Option<Rc<ActualSettings>>,
+    Option<Arc<ActualSettings>>,
     /// A ZST that is not [`Send`] but is [`Sync`]
     ///
     /// This is necessary due to the lack of stable [negative impls](https://github.com/rust-lang/rust/issues/68318).
@@ -677,3 +681,13 @@ impl Drop for SettingsBindDropGuard {
         })
     }
 }
+
+// Prevent accidental removal of Send/Sync (which is a semver-breaking change).
+const _: () = {
+    fn _assert_send_sync<T: Send + Sync>() {}
+    fn _assert() {
+        _assert_send_sync::<Settings>();
+        #[cfg(feature = "redactions")]
+        _assert_send_sync::<Redactions>();
+    }
+};


### PR DESCRIPTION
Patch release restoring `Send + Sync` on `Settings`, `Redactions`, and `Redaction` after the semver-breaking change in 1.47.0.

Follow-up to #893.

> _This was written by Claude Code on behalf of @max-sixty_