### PR TITLE
Fix `--snapshot` filter on Windows; allow partial paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "similar",
  "similar-asserts",
+ "strip-ansi-escapes",
  "tempfile",
  "toml_edit",
  "toml_writer",
@@ -805,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +971,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/cargo-insta/src/cargo.rs
+++ b/cargo-insta/src/cargo.rs
@@ -1,7 +1,6 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub(crate) use cargo_metadata::Package;
-use itertools::Itertools;
 
 /// Find snapshot roots within a package
 // We need this because paths are not always conventional — for example cargo
@@ -35,24 +34,33 @@ pub(crate) fn find_snapshot_roots(package: &Package) -> Vec<PathBuf> {
     // TODO: I think this root reduction is duplicative over the logic in
     // `make_snapshot_walker`; could try removing.
 
-    // reduce roots to avoid traversing into paths twice.  If we have both
-    // /foo and /foo/bar as roots we would only walk into /foo.  Otherwise
-    // we would encounter paths twice.  If we don't skip them here we run
-    // into issues where the existence of a build script causes a snapshot
-    // to be picked up twice since the same path is determined.  (GH-15)
-    let canonical_roots: Vec<_> = roots
-        .iter()
-        .filter_map(|x| x.canonicalize().ok())
-        .sorted_by_key(|x| x.as_os_str().len())
-        .collect();
-
-    canonical_roots
-        .clone()
+    // Reduce roots to avoid traversing into paths twice.  If we have both
+    // `/foo` and `/foo/bar` as roots we only keep `/foo`.  Otherwise we
+    // would encounter the same snapshot twice — e.g. the existence of a
+    // build script can cause the same path to be determined twice.  (GH-15)
+    //
+    // The comparison is done on canonicalized paths so that symlinks and
+    // Windows path quirks (8.3 short names, etc.) don't defeat it, but we
+    // return the *original* paths.  Canonicalized paths on Windows carry a
+    // `\\?\` verbatim prefix that would otherwise leak into snapshot keys
+    // and other user-facing output.  (GH-902)
+    fn canonical(path: &Path) -> PathBuf {
+        path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    }
+    let roots: Vec<(PathBuf, PathBuf)> = roots
         .into_iter()
-        .filter(|root| {
-            !canonical_roots
-                .iter()
-                .any(|x| root.starts_with(x) && root != x)
+        .map(|root| {
+            let canonical = canonical(&root);
+            (root, canonical)
         })
+        .collect();
+    roots
+        .iter()
+        .filter(|(_, canonical)| {
+            !roots
+                .iter()
+                .any(|(_, other)| canonical != other && canonical.starts_with(other))
+        })
+        .map(|(root, _)| root.clone())
         .collect()
 }

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -7,8 +7,8 @@ use std::{io, process};
 
 use console::{set_colors_enabled, style, Key, Term};
 use insta::_cargo_insta_support::{
-    get_cargo, get_pending_dir, is_ci, SnapshotPrinter, SnapshotUpdate, TestRunner, ToolConfig,
-    UnreferencedSnapshots,
+    get_cargo, get_pending_dir, is_ci, path_to_storage, SnapshotPrinter, SnapshotUpdate,
+    TestRunner, ToolConfig, UnreferencedSnapshots,
 };
 use insta::{internals::SnapshotContents, Snapshot};
 use itertools::Itertools;
@@ -112,6 +112,11 @@ struct ProcessCommand {
     #[command(flatten)]
     target_args: TargetArgs,
     /// Limits the operation to one or more snapshots.
+    ///
+    /// A value matches a snapshot whose path (as shown by `cargo insta
+    /// pending-snapshots`) it equals or is a trailing path-component suffix
+    /// of, so a bare file name like `my_test.snap` is usually enough. For
+    /// inline snapshots a `:line` suffix may be appended to disambiguate.
     #[arg(long = "snapshot")]
     snapshot_filter: Option<Vec<String>>,
     /// Do not print to stdout.
@@ -628,19 +633,51 @@ fn load_snapshot_containers<'a>(
     Ok((snapshot_containers, roots))
 }
 
-/// Formats a snapshot key for use in filters and display.
-/// Returns "path" for file snapshots or "path:line" for inline snapshots.
-/// Converts absolute paths to workspace-relative paths.
+/// Formats a snapshot key for display and as the canonical form printed by
+/// `pending-snapshots`.
+///
+/// Returns `"path"` for file snapshots or `"path:line"` for inline snapshots.
+/// The path is workspace-relative (falling back to the absolute path if it
+/// lies outside the workspace) and uses `/` separators on every platform —
+/// the same representation `insta` uses for stored `source:` paths.
 fn format_snapshot_key(workspace_root: &Path, target_file: &Path, line: Option<u32>) -> String {
-    let relative_path = target_file
+    let relative = target_file
         .strip_prefix(workspace_root)
         .unwrap_or(target_file);
-
-    if let Some(line) = line {
-        format!("{}:{}", relative_path.display(), line)
-    } else {
-        format!("{}", relative_path.display())
+    let path = path_to_storage(relative);
+    match line {
+        Some(line) => format!("{path}:{line}"),
+        None => path,
     }
+}
+
+/// Returns whether a `--snapshot` filter entry refers to this snapshot.
+///
+/// A filter matches when its path part is a trailing path-component suffix of
+/// `target_file`, so a bare `name.snap` is enough. For inline snapshots the
+/// filter may carry a `:line` suffix to disambiguate; without it, every inline
+/// snapshot in the file matches. `Path::ends_with` already treats `/` and `\`
+/// as equivalent on Windows, so users can spell separators either way.
+fn snapshot_matches_filter(target_file: &Path, line: Option<u32>, filter: &str) -> bool {
+    // Pull off an optional trailing `:<line>`. We require it to parse as a
+    // line number; otherwise (e.g. a Windows drive letter, a colon in a file
+    // name) it's part of the path.
+    let (path_part, line_part) = match filter.rsplit_once(':') {
+        Some((path, suffix)) => match suffix.parse::<u32>() {
+            Ok(n) => (path, Some(n)),
+            Err(_) => (filter, None),
+        },
+        None => (filter, None),
+    };
+    if path_part.is_empty() && line_part.is_none() {
+        return false;
+    }
+    if let Some(n) = line_part {
+        if line != Some(n) {
+            return false;
+        }
+    }
+    target_file.ends_with(path_part)
 }
 
 /// Processes snapshot files for reviewing, accepting, or rejecting.
@@ -694,8 +731,10 @@ fn review_snapshots(
         for snapshot_ref in snapshot_container.iter_snapshots() {
             // if a filter is provided, check if the snapshot reference is included
             if let Some(filter) = snapshot_filter {
-                let key = format_snapshot_key(&loc.workspace_root, &target_file, snapshot_ref.line);
-                if !filter.contains(&key) {
+                if !filter
+                    .iter()
+                    .any(|f| snapshot_matches_filter(&target_file, snapshot_ref.line, f))
+                {
                     skipped.push(snapshot_ref.summary());
                     continue;
                 }
@@ -1642,5 +1681,87 @@ mod tests {
             .collect();
         assert_eq!(args, vec!["nextest"]);
         env::remove_var("CARGO");
+    }
+
+    #[test]
+    fn test_format_snapshot_key() {
+        let workspace = Path::new("/work/space");
+
+        assert_eq!(
+            format_snapshot_key(workspace, Path::new("/work/space/tests/foo.rs"), Some(42)),
+            "tests/foo.rs:42"
+        );
+        assert_eq!(
+            format_snapshot_key(
+                workspace,
+                Path::new("/work/space/tests/snapshots/foo__bar.snap"),
+                None
+            ),
+            "tests/snapshots/foo__bar.snap"
+        );
+        // Paths outside the workspace fall back to the absolute path.
+        assert_eq!(
+            format_snapshot_key(workspace, Path::new("/elsewhere/foo.snap"), None),
+            "/elsewhere/foo.snap"
+        );
+        // Windows-style separators are normalized to `/`.
+        #[cfg(windows)]
+        assert_eq!(
+            format_snapshot_key(
+                Path::new(r"C:\work\space"),
+                Path::new(r"C:\work\space\tests\snapshots\foo.snap"),
+                None
+            ),
+            "tests/snapshots/foo.snap"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_matches_filter_file() {
+        let target = Path::new("/work/space/crates/foo/tests/snapshots/foo__bar.snap");
+
+        // a bare file name, partial path, or full workspace-relative key all work
+        assert!(snapshot_matches_filter(target, None, "foo__bar.snap"));
+        assert!(snapshot_matches_filter(
+            target,
+            None,
+            "snapshots/foo__bar.snap"
+        ));
+        assert!(snapshot_matches_filter(
+            target,
+            None,
+            "crates/foo/tests/snapshots/foo__bar.snap"
+        ));
+        // partial components must align on a `/` boundary
+        assert!(!snapshot_matches_filter(target, None, "bar.snap"));
+        assert!(!snapshot_matches_filter(target, None, "o__bar.snap"));
+        assert!(!snapshot_matches_filter(target, None, "other.snap"));
+        // empty filter matches nothing
+        assert!(!snapshot_matches_filter(target, None, ""));
+    }
+
+    #[test]
+    fn test_snapshot_matches_filter_inline() {
+        let target = Path::new("/work/space/crates/foo/tests/lib.rs");
+
+        // inline snapshots accept `path:line`
+        assert!(snapshot_matches_filter(target, Some(17), "lib.rs:17"));
+        assert!(snapshot_matches_filter(target, Some(17), "tests/lib.rs:17"));
+        // wrong line is rejected
+        assert!(!snapshot_matches_filter(target, Some(17), "lib.rs:18"));
+        // omitting the line matches every inline snapshot in the file
+        assert!(snapshot_matches_filter(target, Some(17), "lib.rs"));
+        // and a non-numeric "suffix" is treated as part of the file name
+        assert!(!snapshot_matches_filter(target, Some(17), "lib.rs:foo"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_snapshot_matches_filter_windows_separators() {
+        // `Path::ends_with` treats `/` and `\` as equivalent on Windows, so a
+        // user can spell separators either way without us doing string surgery.
+        let target = Path::new(r"C:\work\space\tests\snapshots\foo.snap");
+        assert!(snapshot_matches_filter(target, None, r"snapshots\foo.snap"));
+        assert!(snapshot_matches_filter(target, None, "snapshots/foo.snap"));
     }
 }

--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -78,6 +78,7 @@ mod inline_snapshot_trimming;
 mod nextest_doctest;
 mod pending_dir;
 mod raw_strings;
+mod snapshot_filter;
 mod test_runner_fallback;
 mod test_workspace_source_path;
 mod unreferenced;

--- a/cargo-insta/tests/functional/snapshot_filter.rs
+++ b/cargo-insta/tests/functional/snapshot_filter.rs
@@ -1,0 +1,124 @@
+use insta::assert_snapshot;
+
+use crate::TestFiles;
+
+/// `cargo insta accept --snapshot <name>` should accept only the matching
+/// snapshot, and a bare file name (rather than the full workspace-relative
+/// path that's shown by `pending-snapshots`) is enough. Regression test for
+/// GH-902, which reported that the filter only accepted hard-to-produce
+/// absolute paths (`\\?\C:\...` on Windows).
+#[test]
+fn test_snapshot_filter_partial_name() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("snapshot_filter_partial_name")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_one() {
+    insta::assert_snapshot!("one", "first value");
+}
+
+#[test]
+fn test_two() {
+    insta::assert_snapshot!("two", "second value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    // The first run leaves two pending snapshots.
+    assert!(!&test_project
+        .insta_cmd()
+        .args(["test", "--", "--nocapture"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    assert_snapshot!(test_project.file_tree_diff(), @r"
+    --- Original file tree
+    +++ Updated file tree
+    @@ -1,3 +1,7 @@
+    +  Cargo.lock
+       Cargo.toml
+       src
+         src/lib.rs
+    +    src/snapshots
+    +      src/snapshots/snapshot_filter_partial_name__one.snap.new
+    +      src/snapshots/snapshot_filter_partial_name__two.snap.new
+    ");
+
+    // Accept just one of them, addressed by a bare file name.
+    assert!(&test_project
+        .insta_cmd()
+        .args([
+            "accept",
+            "--snapshot",
+            "snapshot_filter_partial_name__one.snap",
+        ])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    // `one` is now an accepted snapshot; `two` is still pending.
+    assert_snapshot!(test_project.file_tree_diff(), @r"
+    --- Original file tree
+    +++ Updated file tree
+    @@ -1,3 +1,7 @@
+    +  Cargo.lock
+       Cargo.toml
+       src
+         src/lib.rs
+    +    src/snapshots
+    +      src/snapshots/snapshot_filter_partial_name__one.snap
+    +      src/snapshots/snapshot_filter_partial_name__two.snap.new
+    ");
+}
+
+/// `cargo insta pending-snapshots` lists workspace-relative keys with `/`
+/// separators that can be fed straight back to `--snapshot`.
+#[test]
+fn test_pending_snapshots_keys() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("pending_snapshots_keys")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_snap() {
+    insta::assert_snapshot!("snap", "a value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    assert!(!&test_project
+        .insta_cmd()
+        .args(["test", "--", "--nocapture"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let output = test_project
+        .insta_cmd()
+        .args(["pending-snapshots"])
+        .stdout(std::process::Stdio::piped())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // The key is workspace-relative and uses `/` separators on every platform,
+    // so it can be passed straight back to `--snapshot`.
+    assert!(
+        stdout.contains("src/snapshots/pending_snapshots_keys__snap.snap"),
+        "{stdout}"
+    );
+    assert!(
+        !stdout.contains('\\'),
+        "keys should use `/` separators: {stdout}"
+    );
+}

--- a/insta/src/lib.rs
+++ b/insta/src/lib.rs
@@ -363,6 +363,7 @@ pub mod _cargo_insta_support {
         snapshot::TextSnapshotContents,
         utils::get_cargo,
         utils::is_ci,
+        utils::path_to_storage,
     };
 }
 


### PR DESCRIPTION
On Windows, `cargo insta pending-snapshots` printed snapshot paths with the `\\?\` verbatim prefix (e.g. `\\?\C:\path\to\shot.snap`), and `--snapshot <path>` required an exact match against that hard-to-produce string — frustrating for users and especially for LLM tooling that naturally produces relative paths.

Root cause: `find_snapshot_roots` canonicalised search roots, and on Windows `canonicalize()` returns verbatim paths. Those flowed into `target_path` on each `SnapshotContainer`, and `format_snapshot_key`'s `strip_prefix(workspace_root)` then failed (because `workspace_root` is *not* verbatim), so the full `\\?\C:\…` string was emitted.

Fix:

- `find_snapshot_roots` now keeps the GH-15 dedup but compares *canonicalised* forms while returning the *original* (non-verbatim) paths. This also lets `strip_prefix_with_fallback` hit its symlink-preserving direct-strip path for Bazel/`INSTA_PENDING_DIR` mode rather than falling through to canonicalise-both.
- `format_snapshot_key` reuses the existing `insta::utils::path_to_storage` helper so cargo-insta and insta agree on what a stored path looks like (workspace-relative, `/` separators on every platform).
- The `--snapshot` filter is now lenient: a value matches when it is a trailing path-component suffix of the snapshot's target file, so a bare `foo.snap` (or `tests/snapshots/foo.snap`, or the full key) all work. Implemented via `Path::ends_with`, which already treats `/` and `\` as equivalent in the needle on Windows. Inline snapshots may carry an optional `:line` suffix to disambiguate.

Tests: unit tests for `format_snapshot_key` and `snapshot_matches_filter` plus two functional tests (bare-name `accept --snapshot` accepts only the matching snapshot; `pending-snapshots` keys are workspace-relative and `/`-separated).

Closes #902. Thanks to @QuadnucYard for reporting — would you mind giving this a try on Windows once it lands? In particular: `cargo insta pending-snapshots` should now print clean relative paths, and `cargo insta accept --snapshot my_test.snap` (or any trailing-path-suffix) should work.
