### PR TITLE
fix(json): serialize BTreeMap keys with unit enum variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "similar",
  "similar-asserts",
+ "strip-ansi-escapes",
  "tempfile",
  "toml_edit",
  "toml_writer",
@@ -805,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +971,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/insta/src/content/json.rs
+++ b/insta/src/content/json.rs
@@ -104,6 +104,14 @@ impl Serializer {
         self.end_container('}', fields.is_empty());
     }
 
+    fn write_map_key(&mut self, key: &Content) {
+        if let Some(key) = map_key_to_json_string(key) {
+            self.write_escaped_str(&key);
+        } else {
+            panic!("cannot serialize maps without string keys to JSON");
+        }
+    }
+
     pub fn serialize(&mut self, value: &Content) {
         match value {
             Content::Bool(true) => self.write_str("true"),
@@ -157,16 +165,7 @@ impl Serializer {
                 self.start_container('{');
                 for (idx, (key, value)) in map.iter().enumerate() {
                     self.write_comma(idx == 0);
-                    let real_key = key.resolve_inner();
-                    if let Content::String(ref s) = real_key {
-                        self.write_escaped_str(s);
-                    } else if let Some(num) = real_key.as_i64() {
-                        self.write_escaped_str(&num.to_string());
-                    } else if let Some(num) = real_key.as_i128() {
-                        self.write_escaped_str(&num.to_string());
-                    } else {
-                        panic!("cannot serialize maps without string keys to JSON");
-                    }
+                    self.write_map_key(key);
                     self.write_colon();
                     self.serialize(value);
                 }
@@ -283,6 +282,20 @@ static ESCAPE: [u8; 256] = [
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0, // F
 ];
 
+fn map_key_to_json_string(key: &Content) -> Option<String> {
+    match key.resolve_inner() {
+        Content::String(s) => Some(s.clone()),
+        Content::UnitVariant(_, _, variant) => Some(variant.to_string()),
+        Content::Char(c) => Some(c.to_string()),
+        Content::Bool(b) => Some(b.to_string()),
+        k => k
+            .as_i64()
+            .map(|num| num.to_string())
+            .or_else(|| k.as_i128().map(|num| num.to_string()))
+            .or_else(|| k.as_u64().map(|num| num.to_string())),
+    }
+}
+
 /// Serializes a value to JSON.
 pub fn to_string(value: &Content) -> String {
     let mut ser = Serializer::new();
@@ -368,6 +381,32 @@ fn test_to_string_num_keys() {
     {
       "42": true,
       "-23": false
+    }
+    "#);
+}
+
+#[test]
+fn test_to_string_unit_variant_keys() {
+    let content = Content::Map(vec![
+        (
+            Content::UnitVariant("MyEnum", 0, "A"),
+            Content::from(true),
+        ),
+        (
+            Content::UnitVariant("MyEnum", 1, "B"),
+            Content::from(false),
+        ),
+        (
+            Content::UnitVariant("MyEnum", 2, "C"),
+            Content::from(true),
+        ),
+    ]);
+    let json = to_string_pretty(&content);
+    crate::assert_snapshot!(&json, @r#"
+    {
+      "A": true,
+      "B": false,
+      "C": true
     }
     "#);
 }

--- a/insta/tests/test_basic.rs
+++ b/insta/tests/test_basic.rs
@@ -135,3 +135,25 @@ fn test_trailing_crlf_inline() {
     baz
     ");
 }
+
+#[test]
+fn test_btreemap_enum_keys_json() {
+    use serde::Serialize;
+    use std::collections::BTreeMap;
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+    enum MyEnum {
+        A,
+        B,
+        C,
+    }
+
+    let map = BTreeMap::from([(MyEnum::A, true), (MyEnum::B, false), (MyEnum::C, true)]);
+    insta::assert_json_snapshot!(map, @r#"
+    {
+      "A": true,
+      "B": false,
+      "C": true
+    }
+    "#);
+}


### PR DESCRIPTION
## Summary

Fixes #689.

`assert_json_snapshot!` panicked when serializing `BTreeMap` keys that are unit enum variants (e.g. `BTreeMap<MyEnum, bool>`). JSON map keys now support `UnitVariant` names in addition to strings and numeric keys.

## Test plan

- [x] `cargo test -p insta --lib test_to_string_unit_variant_keys`
- [x] `cargo test -p insta --test test_basic test_btreemap_enum_keys_json --features json`
- [ ] CI