### PR TITLE
fix(redactions): apply sorted_redaction after other redactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "similar",
  "similar-asserts",
+ "strip-ansi-escapes",
  "tempfile",
  "toml_edit",
  "toml_writer",
@@ -805,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +971,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/insta/src/redaction.rs
+++ b/insta/src/redaction.rs
@@ -55,6 +55,8 @@ pub enum Redaction {
     Static(Content),
     /// Redaction with new content.
     Dynamic(Box<dyn Fn(Content, ContentPath<'_>) -> Content + Sync + Send>),
+    /// Sorts sequences or maps. Applied after other redactions so ordering is stable.
+    Sort(Box<dyn Fn(Content, ContentPath<'_>) -> Content + Sync + Send>),
 }
 
 macro_rules! impl_from {
@@ -140,6 +142,9 @@ where
 /// (which need to retain order) and sets (which should be given a stable order)
 /// look the same.
 ///
+/// Sort redactions are always applied after other redactions, so their position
+/// in the redaction map does not affect the result.
+///
 /// ```rust
 /// # use insta::{Settings, sorted_redaction};
 /// # let mut settings = Settings::new();
@@ -163,7 +168,7 @@ pub fn sorted_redaction() -> Redaction {
         }
         value
     }
-    dynamic_redaction(sort)
+    Redaction::Sort(Box::new(sort))
 }
 
 /// Creates a redaction that rounds floating point numbers to a given
@@ -188,11 +193,17 @@ pub fn rounded_redaction(decimals: usize) -> Redaction {
 }
 
 impl Redaction {
+    pub(crate) fn is_sort(&self) -> bool {
+        matches!(self, Redaction::Sort(_))
+    }
+
     /// Performs the redaction of the value at the given path.
     fn redact(&self, value: Content, path: &[PathItem]) -> Content {
-        match *self {
-            Redaction::Static(ref new_val) => new_val.clone(),
-            Redaction::Dynamic(ref callback) => callback(value, ContentPath(path)),
+        match self {
+            Redaction::Static(new_val) => new_val.clone(),
+            Redaction::Dynamic(callback) | Redaction::Sort(callback) => {
+                callback(value, ContentPath(path))
+            }
         }
     }
 }

--- a/insta/src/settings.rs
+++ b/insta/src/settings.rs
@@ -40,9 +40,19 @@ impl<'a> From<Vec<(&'a str, Redaction)>> for Redactions {
 #[cfg(feature = "redactions")]
 impl Redactions {
     /// Applies all redactions to the given content.
+    ///
+    /// Sort redactions run after all others so `sorted_redaction()` order in the
+    /// settings map does not affect snapshot stability.
     pub(crate) fn apply_to_content(&self, mut content: Content) -> Content {
-        for (selector, redaction) in self.0.iter() {
-            content = selector.redact(content, redaction);
+        for (selector, redaction) in &self.0 {
+            if !redaction.is_sort() {
+                content = selector.redact(content, redaction);
+            }
+        }
+        for (selector, redaction) in &self.0 {
+            if redaction.is_sort() {
+                content = selector.redact(content, redaction);
+            }
         }
         content
     }
@@ -723,6 +733,43 @@ impl Drop for SettingsBindDropGuard {
         CURRENT_SETTINGS.with(|x| {
             x.borrow_mut().inner = self.0.take().unwrap();
         })
+    }
+}
+
+#[cfg(all(test, feature = "redactions"))]
+mod redaction_order_tests {
+    use super::*;
+    use crate::content::Content;
+    use crate::redaction::sorted_redaction;
+
+    #[test]
+    fn sort_redaction_order_is_independent() {
+        let content = Content::Seq(vec![
+            Content::Struct(
+                "Row",
+                vec![("a", Content::from(true)), ("z", Content::from(2))],
+            ),
+            Content::Struct(
+                "Row",
+                vec![("a", Content::from(false)), ("z", Content::from(1))],
+            ),
+        ]);
+
+        let sort_first: Redactions = vec![
+            (".", sorted_redaction()),
+            ("[].a", Redaction::from("[redacted]")),
+        ]
+        .into();
+        let sort_last: Redactions = vec![
+            ("[].a", Redaction::from("[redacted]")),
+            (".", sorted_redaction()),
+        ]
+        .into();
+
+        assert_eq!(
+            sort_first.apply_to_content(content.clone()),
+            sort_last.apply_to_content(content)
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #683.

`sorted_redaction()` is now applied in a second pass after all other redactions, so snapshot output no longer depends on the order entries appear in the redaction map.

## Changes

- Add `Redaction::Sort` variant used by `sorted_redaction()`
- `Redactions::apply_to_content` runs non-sort redactions first, then sort redactions
- Document that sort redaction order in the map is irrelevant

## Test plan

- [x] `cargo test -p insta --lib --features redactions,json sort_redaction_order`
- [x] `cargo test -p insta --test test_redaction --features redactions,json,yaml`
- [ ] CI