### PR TITLE
feat(cargo-insta): support `cargo insta review --accept`

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -123,6 +123,11 @@ struct ProcessCommand {
 struct ReviewCommand {
     #[command(flatten)]
     process: ProcessCommand,
+    /// Accept all matching snapshots without interactive review.
+    ///
+    /// This is equivalent to `cargo insta accept` with the same filters.
+    #[arg(long)]
+    accept: bool,
     /// External diff tool to use (e.g., "delta --side-by-side").
     #[arg(long, env = "INSTA_DIFF_TOOL")]
     diff_tool: Option<String>,
@@ -1599,7 +1604,11 @@ pub(crate) fn run() -> Result<(), Box<dyn Error>> {
                 cmd.process.quiet,
                 cmd.process.snapshot_filter.as_deref(),
                 &handle_target_args(&cmd.process.target_args, &[])?,
-                None,
+                if cmd.accept {
+                    Some(Operation::Accept)
+                } else {
+                    None
+                },
             )
         }
         Command::Accept(ref cmd) | Command::Reject(ref cmd) => review_snapshots(


### PR DESCRIPTION
## Summary

Adds `--accept` to `cargo insta review` so it accepts all matching snapshots without interactive review — equivalent to `cargo insta accept` with the same filters (`--package`, `--snapshot`, etc.).

Fixes #901

## Motivation

Tools and LLM workflows often try `cargo insta review --accept` and fail with an unknown flag error. This alias makes that usage valid without changing the existing `cargo insta accept` command.

## Test plan

- [x] `cargo test -p cargo-insta` (103 tests passed locally)