### PR TITLE
fix: regenerate Cargo.lock and guard it with --locked in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "serde",
  "similar",
  "similar-asserts",
+ "strip-ansi-escapes",
  "tempfile",
  "toml_edit",
  "toml_writer",
@@ -805,6 +806,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +971,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ test: cargotest
 
 cargotest:
 	@echo "CARGO TESTS"
-	@cargo test -p insta
-	@cargo test -p insta --all-features
-	@cargo test -p insta --no-default-features
-	@cargo test -p insta --features redactions -- --test-threads 1
-	@cargo test -p cargo-insta
+	@cargo test -p insta --locked
+	@cargo test -p insta --all-features --locked
+	@cargo test -p insta --no-default-features --locked
+	@cargo test -p insta --features redactions --locked -- --test-threads 1
+	@cargo test -p cargo-insta --locked
 
 check-minver:
 	@echo "MINVER CHECK"


### PR DESCRIPTION
`Cargo.lock` was missing `strip-ansi-escapes` and its dependency `vte`. #899 added `strip-ansi-escapes` to `insta/Cargo.toml` but didn't update the lockfile, and CI didn't notice: no cargo command runs with `--locked`, so every invocation silently regenerated the lockfile in the workspace and passed.

This regenerates `Cargo.lock` to add the two entries, and adds `--locked` to the `cargotest` make target. The `test-latest` job runs `make test`, so a stale lockfile now fails CI instead of being silently regenerated.

> _This was written by Claude Code on behalf of max_
