### PR TITLE
fix: translate --profile to --cargo-profile for nextest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## Unreleased
+
+- Fix `cargo insta test --profile` being forwarded to nextest as the nextest
+  profile instead of the cargo build profile; it now translates to
+  `--cargo-profile` for the nextest runner. Add `--nextest-profile` to select
+  the nextest profile. #910
+
 ## 1.47.2
 
 - Restore `Send + Sync` on `Settings`, `Redactions`, and `Redaction` by

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -167,9 +167,19 @@ struct TestRunnerOptions {
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long)]
     release: bool,
-    /// Build artifacts with the specified profile
+    /// Build artifacts with the specified cargo profile
     #[arg(long)]
     profile: Option<String>,
+    // Exposing a nextest-specific flag on `insta` isn't ideal: runner-specific
+    // options would ideally pass through to the runner rather than be modeled
+    // here. But insta's passthrough (`cargo insta test -- ...`) is emitted after
+    // the synthesized `--`, landing in nextest's emulated-libtest slot, which
+    // can't reach the front-end where the nextest profile (`-P`/`--profile`)
+    // lives. Lacking a front-end passthrough, a dedicated flag is the only way
+    // to expose it. See https://github.com/mitsuhiko/insta/issues/910
+    /// nextest profile to use (only with `--test-runner nextest`)
+    #[arg(long)]
+    nextest_profile: Option<String>,
     /// Test all targets (does not include doctests)
     #[arg(long)]
     all_targets: bool,
@@ -1351,8 +1361,25 @@ fn prepare_test_runner<'snapshot_ref>(
         proc.arg("--release");
     }
     if let Some(ref profile) = cmd.test_runner_options.profile {
-        proc.arg("--profile");
+        // `--profile` selects the cargo build profile. `cargo test` spells this
+        // `--profile`, but `cargo nextest run` spells it `--cargo-profile` (its
+        // own `--profile`/`-P` selects the *nextest* profile, exposed as
+        // `--nextest-profile`). See https://github.com/mitsuhiko/insta/issues/910
+        proc.arg(match test_runner {
+            TestRunner::Nextest => "--cargo-profile",
+            TestRunner::CargoTest | TestRunner::Auto => "--profile",
+        });
         proc.arg(profile);
+    }
+    if let Some(ref nextest_profile) = cmd.test_runner_options.nextest_profile {
+        if !matches!(test_runner, TestRunner::Nextest) {
+            return Err(err_msg(
+                "--nextest-profile requires `--test-runner nextest`",
+            ));
+        }
+        // For nextest, `--profile`/`-P` is the nextest profile.
+        proc.arg("--profile");
+        proc.arg(nextest_profile);
     }
     if cmd.test_runner_options.all_targets {
         proc.arg("--all-targets");


### PR DESCRIPTION
This is not a _great_ design, but I'm not sure if there's a better one... 

comments from Claude below

---


`cargo insta test --profile` is documented as the cargo build profile, and that's how it behaves under `cargo test`. But `cargo nextest run` spells the build profile `--cargo-profile` and reserves `--profile`/`-P` for its own nextest profile, so forwarding `--profile` unchanged meant nextest silently received it as a nextest profile rather than the build profile.

This translates `--profile` to `--cargo-profile` when the runner is nextest, and leaves it as `--profile` for `cargo test`, so the flag means the same thing on both runners.

It also adds `--nextest-profile` to reach nextest's `-P`/`--profile`. That part isn't ideal: a nextest-specific flag on insta would ideally pass through to the runner rather than be modeled here, but insta's `-- ...` passthrough is emitted after the synthesized `--`, landing in nextest's emulated-libtest slot, so it can't reach the front-end where the nextest profile lives. Until there's a front-end passthrough, a dedicated flag is the only way to expose it; a comment on the field records this.

Related but not addressed here: `-j`/`--jobs` is forwarded with the same spelling to both runners but means build jobs for `cargo test` and test threads for nextest. I'm happy to follow up on that separately.

Closes #910. Thanks to @tomasol for reporting.

> _This was written by Claude Code on behalf of max_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
