### PR TITLE
fix: tolerate a missing binary snapshot data file

### DIFF
--- a/cargo-insta/tests/functional/binary.rs
+++ b/cargo-insta/tests/functional/binary.rs
@@ -1,3 +1,6 @@
+use std::fs;
+use std::process::Command;
+
 use insta::assert_snapshot;
 
 use crate::TestFiles;
@@ -340,6 +343,85 @@ fn test() {
     +    src/snapshots
     +      src/snapshots/test_change_binary_to_text__some_name.snap
     ");
+}
+
+/// Regression test for https://github.com/mitsuhiko/insta/issues/911
+///
+/// A binary snapshot's data file can be `.gitignore`d by extension while its
+/// `.snap` metadata file stays tracked. On a fresh checkout the metadata is
+/// present but the data file is absent. Accepting a new value then used to fail
+/// with a nonspecific `No such file or directory (os error 2)` (even with
+/// `--include-ignored`), because loading the snapshot read the *old* target's
+/// missing data file and aborted the whole accept. The old data is not needed
+/// to accept the new snapshot, so a missing one is now tolerated.
+#[test]
+fn test_binary_accept_missing_old_binary() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("test_binary_accept_missing_old_binary")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_binary_snapshot() {
+    insta::assert_binary_snapshot!(".txt", b"test".to_vec());
+}
+"#
+            .to_string(),
+        )
+        // The binary data files (`*.txt`) are ignored by extension; their `.snap`
+        // metadata files are tracked.
+        .add_file(".gitignore", "*.txt\n".to_string())
+        .create_project();
+
+    // Initialize a git repository so `.gitignore` is honored.
+    Command::new("git")
+        .current_dir(&test_project.workspace_dir)
+        .args(["init"])
+        .output()
+        .unwrap();
+
+    let snapshot = test_project
+        .workspace_dir
+        .join("src/snapshots/test_binary_accept_missing_old_binary__binary_snapshot.snap");
+    let data_file = snapshot.with_extension("snap.txt");
+
+    // Accept once to create the tracked metadata file and its (ignored) data file.
+    assert!(&test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+    assert!(snapshot.exists());
+    assert!(data_file.exists());
+
+    // Simulate a fresh checkout: the ignored data file was never committed, so
+    // only the metadata file is present.
+    fs::remove_file(&data_file).unwrap();
+
+    // Change the value and accept the new snapshot. The missing old data file
+    // must not abort the accept.
+    test_project.update_file(
+        "src/lib.rs",
+        r#"
+#[test]
+fn test_binary_snapshot() {
+    insta::assert_binary_snapshot!(".txt", b"changed".to_vec());
+}
+"#
+        .to_string(),
+    );
+    let output = test_project
+        .insta_cmd()
+        .args(["test", "--accept"])
+        .output()
+        .unwrap();
+
+    assert!(&output.status.success());
+
+    // The new value is written to the data file.
+    assert_eq!(fs::read(&data_file).unwrap(), b"changed");
 }
 
 #[test]

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -898,7 +898,7 @@ pub fn assert_snapshot(
                 "file extensions starting with 'new.' are not allowed",
             );
 
-            SnapshotContents::Binary(Rc::new(content))
+            SnapshotContents::Binary(Some(Rc::new(content)))
         }
     };
 

--- a/insta/src/snapshot.rs
+++ b/insta/src/snapshot.rs
@@ -8,7 +8,7 @@ use std::env;
 use std::error::Error;
 use std::fmt;
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -406,9 +406,14 @@ impl Snapshot {
             }
             SnapshotKind::Binary { ref extension } => {
                 let path = build_binary_path(extension, p);
-                let contents = fs::read(path)?;
-
-                SnapshotContents::Binary(Rc::new(contents))
+                // A missing sidecar data file is a valid state (see
+                // `SnapshotContents::Binary`); we represent it as `None` rather than
+                // erroring. A present-but-unreadable file is still a real error.
+                match fs::read(path) {
+                    Ok(contents) => SnapshotContents::Binary(Some(Rc::new(contents))),
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => SnapshotContents::Binary(None),
+                    Err(e) => return Err(e.into()),
+                }
             }
         };
 
@@ -542,6 +547,12 @@ impl Snapshot {
             .map_err(|e| content::Error::FileIo(e, path.to_path_buf()))?;
 
         if let SnapshotContents::Binary(ref contents) = self.snapshot {
+            // Only snapshots we just produced are ever saved, and those always carry
+            // their data. An absent payload (loaded from disk with a missing sidecar)
+            // has nothing to write.
+            let contents = contents
+                .as_ref()
+                .expect("cannot save a binary snapshot with an absent data file");
             fs::write(self.build_binary_path(path).unwrap(), &**contents)
                 .map_err(|e| content::Error::FileIo(e, path.to_path_buf()))?;
         }
@@ -581,11 +592,17 @@ impl Snapshot {
 pub enum SnapshotContents {
     Text(TextSnapshotContents),
 
+    // `None` represents an absent payload: the `.snap` metadata exists but the
+    // sidecar data file does not. A gitignored data file is never committed, so
+    // it is absent on a fresh checkout even though the metadata is tracked. This
+    // is a valid state for an old snapshot loaded from disk; new snapshots always
+    // carry their data as `Some`.
+    //
     // This is in an `Rc` because we need to be able to clone this struct cheaply and the contents
     // of the `Vec` could be rather large. The reason it's not an `Rc<[u8]>` is because creating one
     // of those would require re-allocating because of the additional size needed for the reference
     // count.
-    Binary(Rc<Vec<u8>>),
+    Binary(Option<Rc<Vec<u8>>>),
 }
 
 // Could be Cow, but I think limited savings
@@ -828,6 +845,10 @@ impl PartialEq for SnapshotContents {
                     false
                 }
             }
+            // Two present payloads compare by bytes. A present payload never equals an
+            // absent one, so an old `None` (missing data file) vs a new `Some(..)` is
+            // unequal — i.e. treated as changed, which is what we want. Two absent
+            // payloads compare equal (there's nothing to distinguish them).
             (SnapshotContents::Binary(this), SnapshotContents::Binary(other)) => this == other,
             _ => false,
         }
@@ -1319,7 +1340,7 @@ fn test_snapshot_contents_as_text() {
     assert!(text.as_text().is_some());
     assert_eq!(text.as_text().unwrap().to_string(), "hello");
 
-    let binary = SnapshotContents::Binary(Rc::new(vec![1, 2, 3]));
+    let binary = SnapshotContents::Binary(Some(Rc::new(vec![1, 2, 3])));
     assert!(binary.as_text().is_none());
 }
 


### PR DESCRIPTION
`cargo insta accept` (and `cargo insta test --accept`) fails with a nonspecific `No such file or directory (os error 2)` and refuses to accept whenever a tracked `.snap` binary snapshot's data file is absent, even with `--include-ignored`. That absence is the normal state after checking out a project that gitignores its binary data files: the `.snap` metadata is committed but the data files are not, so they're missing on any fresh clone, on CI, or after `git clean`. This is the setup reported in #911.

The cause isn't the ignore walker, which is why `--include-ignored` doesn't help. When a snapshot is loaded, `Snapshot::from_file` eagerly `fs::read`s the binary sidecar, and a missing sidecar makes that `?` abort the whole load. But `cargo-insta` only needs the old snapshot's metadata here (it never reads the old binary's bytes, only the extension, to clean up a stale file), and insta's own runtime already tolerates a missing old snapshot during `cargo insta test`. So the abort was an inconsistency, and one you couldn't recover from with the obvious `accept`.

This makes an absent payload a first-class state. `SnapshotContents::Binary` now holds `Option<Rc<Vec<u8>>>`; `from_file` maps a `NotFound` data file to `None` instead of erroring (a present-but-unreadable file still errors). A freshly produced snapshot always carries `Some`. This fixes both the `accept` crash and the misleading `Failed to parse snapshot file` warning the runtime printed in the same scenario.

Note: this changes the shape of the public `SnapshotContents::Binary` variant. No call site in either crate binds the payload directly (all match via `_`, `{ .. }`, or `unreachable!()`), so nothing else needed touching, but it's a public-type change worth a semver note.

Includes a functional test (`test_binary_accept_missing_old_binary`) that reproduces the failure (tracked `.snap`, absent data file, then `accept`) and passes with the fix.

Closes #911. Thanks to @Kinrany for the report.

> _This was written by Claude Code on behalf of max_
