### PR TITLE
Improve `--snapshot` filter feedback in cargo-insta

### DIFF
--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -714,6 +714,10 @@ fn review_snapshots(
     let mut accepted = vec![];
     let mut rejected = vec![];
     let mut skipped = vec![];
+    // Track which `--snapshot` filter entries matched something, so we can warn
+    // about entries that hit nothing. The leftover `skipped` keys then double as
+    // the list of still-pending snapshots to suggest instead.
+    let mut matched_filters = vec![false; snapshot_filter.map_or(0, |f| f.len())];
     let mut num = 0;
     let mut show_info = true;
     let mut show_diff = true;
@@ -729,13 +733,22 @@ fn review_snapshots(
         let target_file = snapshot_container.target_file().to_path_buf();
         let snapshot_file = snapshot_container.snapshot_file().map(|x| x.to_path_buf());
         for snapshot_ref in snapshot_container.iter_snapshots() {
+            // The canonical key is what `pending-snapshots` prints and what
+            // `--snapshot` accepts. Show it wherever a snapshot is listed — the
+            // bare snapshot name shown in the diff header is not a usable filter.
+            let key = format_snapshot_key(&loc.workspace_root, &target_file, snapshot_ref.line);
+
             // if a filter is provided, check if the snapshot reference is included
             if let Some(filter) = snapshot_filter {
-                if !filter
-                    .iter()
-                    .any(|f| snapshot_matches_filter(&target_file, snapshot_ref.line, f))
-                {
-                    skipped.push(snapshot_ref.summary());
+                let mut matched = false;
+                for (i, f) in filter.iter().enumerate() {
+                    if snapshot_matches_filter(&target_file, snapshot_ref.line, f) {
+                        matched_filters[i] = true;
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    skipped.push(key);
                     continue;
                 }
             }
@@ -767,13 +780,11 @@ fn review_snapshots(
 
                 // If we're in review mode (no op), just show instructions and skip
                 if op.is_none() {
-                    let key =
-                        format_snapshot_key(&loc.workspace_root, &target_file, snapshot_ref.line);
                     println!("To accept: cargo insta accept --snapshot '{}'", key);
                     println!("To reject: cargo insta reject --snapshot '{}'", key);
                     println!();
 
-                    skipped.push(snapshot_ref.summary());
+                    skipped.push(key);
                     continue;
                 }
                 // Otherwise fall through to apply the operation (reject)
@@ -821,14 +832,14 @@ fn review_snapshots(
             match op {
                 Operation::Accept | Operation::AcceptAll => {
                     snapshot_ref.op = Operation::Accept;
-                    accepted.push(snapshot_ref.summary());
+                    accepted.push(key);
                 }
                 Operation::Reject | Operation::RejectAll => {
                     snapshot_ref.op = Operation::Reject;
-                    rejected.push(snapshot_ref.summary());
+                    rejected.push(key);
                 }
                 Operation::Skip | Operation::SkipAll => {
-                    skipped.push(snapshot_ref.summary());
+                    skipped.push(key);
                 }
             }
         }
@@ -855,8 +866,35 @@ fn review_snapshots(
         }
         if !skipped.is_empty() {
             println!("{}:", style("skipped").yellow());
-            for item in skipped {
+            for item in &skipped {
                 println!("  {item}");
+            }
+        }
+    }
+
+    // Warn about any `--snapshot` entry that matched nothing rather than
+    // silently leaving everything skipped, and suggest the keys that would
+    // work — the snapshots left in `skipped` are exactly the ones still pending.
+    if let Some(filters) = snapshot_filter {
+        let unmatched = filters
+            .iter()
+            .zip(&matched_filters)
+            .filter(|(_, matched)| !**matched)
+            .map(|(filter, _)| filter)
+            .collect_vec();
+        if !unmatched.is_empty() {
+            for filter in unmatched {
+                eprintln!(
+                    "{} --snapshot '{}' didn't match any pending snapshot",
+                    style("warning:").bold().yellow(),
+                    filter
+                );
+            }
+            if !skipped.is_empty() {
+                eprintln!("pending snapshots (pass any of these to --snapshot):");
+                for key in &skipped {
+                    eprintln!("  {key}");
+                }
             }
         }
     }

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -715,8 +715,7 @@ fn review_snapshots(
     let mut rejected = vec![];
     let mut skipped = vec![];
     // Track which `--snapshot` filter entries matched something, so we can warn
-    // about entries that hit nothing. The leftover `skipped` keys then double as
-    // the list of still-pending snapshots to suggest instead.
+    // about entries that hit nothing.
     let mut matched_filters = vec![false; snapshot_filter.map_or(0, |f| f.len())];
     let mut num = 0;
     let mut show_info = true;
@@ -866,35 +865,23 @@ fn review_snapshots(
         }
         if !skipped.is_empty() {
             println!("{}:", style("skipped").yellow());
-            for item in &skipped {
+            for item in skipped {
                 println!("  {item}");
             }
         }
     }
 
     // Warn about any `--snapshot` entry that matched nothing rather than
-    // silently leaving everything skipped, and suggest the keys that would
-    // work — the snapshots left in `skipped` are exactly the ones still pending.
+    // silently leaving everything skipped. The pending keys to use instead are
+    // already shown in the `skipped:` list above, so we don't repeat them here.
     if let Some(filters) = snapshot_filter {
-        let unmatched = filters
-            .iter()
-            .zip(&matched_filters)
-            .filter(|(_, matched)| !**matched)
-            .map(|(filter, _)| filter)
-            .collect_vec();
-        if !unmatched.is_empty() {
-            for filter in unmatched {
+        for (filter, matched) in filters.iter().zip(&matched_filters) {
+            if !*matched {
                 eprintln!(
                     "{} --snapshot '{}' didn't match any pending snapshot",
                     style("warning:").bold().yellow(),
                     filter
                 );
-            }
-            if !skipped.is_empty() {
-                eprintln!("pending snapshots (pass any of these to --snapshot):");
-                for key in &skipped {
-                    eprintln!("  {key}");
-                }
             }
         }
     }

--- a/cargo-insta/tests/functional/snapshot_filter.rs
+++ b/cargo-insta/tests/functional/snapshot_filter.rs
@@ -51,17 +51,28 @@ fn test_two() {
     ");
 
     // Accept just one of them, addressed by a bare file name.
-    assert!(&test_project
+    let output = test_project
         .insta_cmd()
         .args([
             "accept",
             "--snapshot",
             "snapshot_filter_partial_name__one.snap",
         ])
+        .stdout(std::process::Stdio::piped())
         .output()
-        .unwrap()
-        .status
-        .success());
+        .unwrap();
+    assert!(output.status.success());
+    // Each snapshot is listed by its canonical key — the same string that works
+    // as a `--snapshot` filter — not the bare snapshot name. `one` matched and
+    // was accepted; `two` didn't match the filter so it's listed as skipped.
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert_snapshot!(stdout, @"
+    insta review finished
+    accepted:
+      src/snapshots/snapshot_filter_partial_name__one.snap
+    skipped:
+      src/snapshots/snapshot_filter_partial_name__two.snap
+    ");
 
     // `one` is now an accepted snapshot; `two` is still pending.
     assert_snapshot!(test_project.file_tree_diff(), @r"
@@ -75,6 +86,73 @@ fn test_two() {
     +    src/snapshots
     +      src/snapshots/snapshot_filter_partial_name__one.snap
     +      src/snapshots/snapshot_filter_partial_name__two.snap.new
+    ");
+}
+
+/// A `--snapshot` filter that matches nothing should warn and point at the
+/// keys that would work, rather than silently leaving every snapshot skipped.
+/// The bare snapshot name (`greeting`) is *not* a usable filter because the
+/// on-disk file is module-prefixed (`..._greeting.snap`). Regression test for
+/// the follow-up reported on GH-904.
+#[test]
+fn test_snapshot_filter_no_match_warns() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("snapshot_filter_no_match")
+        .add_file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test_greeting() {
+    insta::assert_snapshot!("greeting", "hello");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    assert!(!&test_project
+        .insta_cmd()
+        .args(["test", "--", "--nocapture"])
+        .output()
+        .unwrap()
+        .status
+        .success());
+
+    let output = test_project
+        .insta_cmd()
+        .args(["accept", "--snapshot", "greeting.snap"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .unwrap();
+    // A no-op accept is not itself an error: the unmatched snapshot is just
+    // listed as skipped on stdout...
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert_snapshot!(stdout, @"
+    insta review finished
+    skipped:
+      src/snapshots/snapshot_filter_no_match__greeting.snap
+    ");
+    // ...and stderr warns the filter hit nothing, then suggests the real key.
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    assert_snapshot!(stderr, @"
+    warning: --snapshot 'greeting.snap' didn't match any pending snapshot
+    pending snapshots (pass any of these to --snapshot):
+      src/snapshots/snapshot_filter_no_match__greeting.snap
+    ");
+
+    // Nothing was accepted: the snapshot is still pending.
+    assert_snapshot!(test_project.file_tree_diff(), @r"
+    --- Original file tree
+    +++ Updated file tree
+    @@ -1,3 +1,6 @@
+    +  Cargo.lock
+       Cargo.toml
+       src
+         src/lib.rs
+    +    src/snapshots
+    +      src/snapshots/snapshot_filter_no_match__greeting.snap.new
     ");
 }
 

--- a/cargo-insta/tests/functional/snapshot_filter.rs
+++ b/cargo-insta/tests/functional/snapshot_filter.rs
@@ -134,13 +134,11 @@ fn test_greeting() {
     skipped:
       src/snapshots/snapshot_filter_no_match__greeting.snap
     ");
-    // ...and stderr warns the filter hit nothing, then suggests the real key.
+    // ...and stderr warns that the filter hit nothing. The key to use instead
+    // is the one already shown under `skipped:` on stdout, so the warning
+    // doesn't repeat it.
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-    assert_snapshot!(stderr, @"
-    warning: --snapshot 'greeting.snap' didn't match any pending snapshot
-    pending snapshots (pass any of these to --snapshot):
-      src/snapshots/snapshot_filter_no_match__greeting.snap
-    ");
+    assert_snapshot!(stderr, @"warning: --snapshot 'greeting.snap' didn't match any pending snapshot");
 
     // Nothing was accepted: the snapshot is still pending.
     assert_snapshot!(test_project.file_tree_diff(), @r"


### PR DESCRIPTION
Follow-up to #904, addressing @QuadnucYard's feedback there.

Two related fixes to how `cargo insta accept/reject/review --snapshot` reports what it did:

The accepted/rejected/skipped lists now print each snapshot's canonical key (the same workspace-relative path `pending-snapshots` prints and `--snapshot` accepts) instead of the bare snapshot name. The bare name was never a usable filter, because the on-disk file is module-prefixed (`mod__name.snap`).

A `--snapshot` entry that matches nothing now produces a warning on stderr, rather than silently leaving every snapshot under `skipped:`. Exit status is unchanged, so a no-op accept still succeeds. The pending keys to use instead are already in the `skipped:` list on stdout, so the warning doesn't repeat them.

The functional tests snapshot the full command output, so the new format is visible in the diff:

```
stdout:
insta review finished
skipped:
  src/snapshots/snapshot_filter_no_match__greeting.snap

stderr:
warning: --snapshot 'greeting.snap' didn't match any pending snapshot
```

Thanks to @QuadnucYard for the suggestions in #904.

> _This was written by Claude Code on behalf of max_
