### PR TITLE
fix: `**` redaction selectors no longer match paths shorter than their suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## Unreleased
+
+- Fix `**` redaction selectors with two or more segments after the wildcard
+  (e.g. `.**.a.b` or `.**[].*`) spuriously matching paths too short to contain
+  those trailing segments. The segments after `**` are matched against the end
+  of the path, so a path shorter than that suffix is no longer treated as a
+  match. #687
+
 ## 1.47.2
 
 - Restore `Send + Sync` on `Settings`, `Redactions`, and `Redaction` by

--- a/insta/src/redaction.rs
+++ b/insta/src/redaction.rs
@@ -488,6 +488,24 @@ impl<'a> Selector<'a> {
         redaction: &Redaction,
         path: &mut Vec<PathItem>,
     ) -> Content {
+        // On a match we redact and stop descending. For a deep wildcard this
+        // means `.**` only redacts the shallowest match on each branch:
+        // `.** => rounded_redaction(n)` rounds the top-level value but not
+        // numbers nested inside arrays, because the array matches `**` first and
+        // descent stops here.
+        //
+        // From scratch this is arguably the wrong default. JSONPath `..` and jq
+        // `..` recurse into every descendant, and the cleaner model is to redact
+        // on a match and then keep descending into the result (which also lets
+        // overlapping selectors like `.a` and `.a.b` compose instead of the
+        // first swallowing the second). We keep stop-on-match purely for
+        // backwards compatibility: existing `.** => sorted_redaction()` /
+        // `dynamic_redaction(...)` snapshots depend on it, and recursing would
+        // resort / re-redact nested collections and silently change their
+        // output. To reach every leaf through arrays and maps, give the wildcard
+        // a trailing segment instead — `.**.<field>` (see
+        // `test_redact_recursive_array`).
+        // Background: https://github.com/mitsuhiko/insta/issues/687
         if self.is_match(path) {
             redaction.redact(value, path)
         } else {

--- a/insta/src/redaction.rs
+++ b/insta/src/redaction.rs
@@ -388,7 +388,24 @@ impl<'a> Selector<'a> {
             let forward_sel = &selector[..idx];
             let backward_sel = &selector[idx + 1..];
 
-            if path.len() <= idx {
+            // `**` matches zero or more path segments between the forward part
+            // (the segments before `**`) and the backward part (those after
+            // it). The backward part is matched against the *tail* of the path
+            // by zipping both in reverse, so the path must be long enough to
+            // hold the forward and backward parts without them overlapping.
+            // The old check (`path.len() <= idx`) only accounted for the
+            // forward part: when the backward part had two or more segments, a
+            // too-short path slipped through and the reverse `zip` silently
+            // truncated to the shorter side, matching only the final
+            // segment(s). For example `.**.a.b` would match a one-segment path
+            // like a top-level `b` (comparing `b` against the trailing `.b`
+            // alone) and redact it. Requiring room for both ends fixes that.
+            //
+            // With no backward part, `**` must still consume at least one
+            // segment (hence `.max(1)`), so `.**` never matches the root and
+            // `.foo.**` never matches `foo` itself — preserving the previous
+            // behavior for those common cases.
+            if path.len() < forward_sel.len() + backward_sel.len().max(1) {
                 return false;
             }
 

--- a/insta/tests/test_redaction.rs
+++ b/insta/tests/test_redaction.rs
@@ -451,6 +451,42 @@ fn test_redact_recursive_array() {
     "#);
 }
 
+#[cfg(feature = "json")]
+#[test]
+fn test_redact_deep_wildcard_suffix_length() {
+    // The segments after `**` are matched against the *end* of the path, so a
+    // path must be at least as long as that suffix to match. `.**.a.b` must
+    // therefore only match a value reached via `.a.b`, never a top-level `b`:
+    // the path `.b` is a single segment and cannot contain the two-segment
+    // `.a.b` suffix.
+    //
+    // This pins the fix for the length guard in `selector_is_match`. Previously
+    // the backward match zipped the suffix against the reversed path and
+    // truncated to the shorter side, so `.b` matched against the trailing `.b`
+    // alone and the top-level `b` was redacted by mistake.
+    #[derive(Serialize)]
+    struct Inner {
+        b: u32,
+    }
+
+    #[derive(Serialize)]
+    struct Root {
+        b: u32,
+        a: Inner,
+    }
+
+    assert_json_snapshot!(Root { b: 1, a: Inner { b: 2 } }, {
+        ".**.a.b" => "[redacted]",
+    }, @r#"
+    {
+      "b": 1,
+      "a": {
+        "b": "[redacted]"
+      }
+    }
+    "#);
+}
+
 #[cfg(feature = "yaml")]
 #[test]
 fn test_struct_array_redaction() {

--- a/insta/tests/test_redaction.rs
+++ b/insta/tests/test_redaction.rs
@@ -397,6 +397,60 @@ fn test_redact_recursive() {
     "#);
 }
 
+#[cfg(feature = "json")]
+#[test]
+fn test_redact_recursive_array() {
+    // A deep wildcard recurses through arrays, not just nested structs: `.**.data`
+    // matches every `data` field at any depth inside the `nodes` vectors. A bare
+    // `.**` would instead match each `nodes` array itself and stop descending, so
+    // only the root would be redacted. See https://github.com/mitsuhiko/insta/issues/687.
+    #[derive(Serialize)]
+    pub struct Node {
+        data: f64,
+        nodes: Vec<Node>,
+    }
+
+    let root = Node {
+        data: 1.111_111,
+        nodes: vec![
+            Node {
+                data: 2.222_222,
+                nodes: vec![Node {
+                    data: 3.333_333,
+                    nodes: vec![],
+                }],
+            },
+            Node {
+                data: 4.444_444,
+                nodes: vec![],
+            },
+        ],
+    };
+
+    assert_json_snapshot!(root, {
+        ".**.data" => insta::rounded_redaction(2),
+    }, @r#"
+    {
+      "data": 1.11,
+      "nodes": [
+        {
+          "data": 2.22,
+          "nodes": [
+            {
+              "data": 3.33,
+              "nodes": []
+            }
+          ]
+        },
+        {
+          "data": 4.44,
+          "nodes": []
+        }
+      ]
+    }
+    "#);
+}
+
 #[cfg(feature = "yaml")]
 #[test]
 fn test_struct_array_redaction() {


### PR DESCRIPTION
A `**` deep-wildcard redaction selector with two or more segments after the wildcard — e.g. `.**.a.b` or `.**[].*` — could match paths too short to contain those trailing segments.

The segments after `**` are matched against the end of the path by zipping the suffix and the path in reverse. The length guard only required room for the segments *before* `**`, so a too-short path slipped through and the reverse `zip` silently truncated to the shorter side, matching on the tail alone. Concretely, `.**.a.b => "[x]"` would redact a top-level `b` by comparing it against just the trailing `.b`. The guard now requires the path to be long enough to hold both the forward and backward parts; with no backward part `**` still must consume at least one segment, so `.**` and `.foo.**` are unchanged.

## Scope

No behavior change for `**` selectors with zero or one trailing segment (`.**`, `.foo.**`, `.**.id`, `.*[].**`) — the guard is identical to before for those. Only selectors with a two-plus-segment suffix after `**`, which previously over-matched, are affected.

## Context

Found while investigating #687 (redacting every value in a recursive structure). The recommended approach for that — `.**.<field>`, which recurses through arrays and maps — already works and is covered by `test_redact_recursive_array`.

This PR is the adjacent correctness fix, **not** the field-agnostic bare-`.**` behavior change discussed in the issue. That change would alter snapshots for existing `**` + structure-preserving redaction users, so it was intentionally left out. Real examples found via GitHub code search:

- **lumen-oss/lux** — `.** => sorted_redaction()` over a lockfile: [`lux-lib/src/lockfile/mod.rs#L1385`](https://github.com/lumen-oss/lux/blob/6806368524238fdab2f1d1fa93302e0ba4a5463c/lux-lib/src/lockfile/mod.rs#L1385) and [`#L1438`](https://github.com/lumen-oss/lux/blob/6806368524238fdab2f1d1fa93302e0ba4a5463c/lux-lib/src/lockfile/mod.rs#L1438)
- **blainehansen/postgres-static-analyzer** — `.** => sorted_redaction()`: [`reflect/src/reflect_test.rs#L14`](https://github.com/blainehansen/postgres-static-analyzer/blob/4b75114b2b692dce741b1e8b64b4824787ec81f4/reflect/src/reflect_test.rs#L14)
- **prisma/prisma-engines** — `.*[].** => redact_id()` (a custom `dynamic_redaction`), across ~13 telemetry tests: [`libs/telemetry/src/layer.rs#L430`](https://github.com/prisma/prisma-engines/blob/3c6e192761c0362d496ed980de936e2f3cebcd3a/libs/telemetry/src/layer.rs#L430)

## Tests

`test_redact_deep_wildcard_suffix_length` pins that `.**.a.b` redacts a nested `a.b` but not a top-level `b`. Full insta and cargo-insta suites pass; clippy and rustfmt clean.

> _This was written by Claude Code on behalf of max_
