### PR TITLE
Deep wildcard (`**`) redactions recurse into arrays (breaking proposal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
+## Unreleased
+
+- Deep wildcard (`**`) redactions now recurse into arrays. A `**` selector that
+  matches a collection (such as a bare `.**`) applies the redaction to every
+  descendant instead of stopping at the first matched collection, so
+  `.** => rounded_redaction(n)` rounds every float in a recursive tree. As a
+  result, `.**` combined with `sorted_redaction()` or a `dynamic_redaction` now
+  runs on more nodes (nested collections, array elements, and map keys), which
+  may change existing snapshots. #687
+- Fix `**` redaction selectors with two or more segments after the wildcard
+  (e.g. `.**.a.b` or `.**[].*`) spuriously matching paths too short to contain
+  those trailing segments. #687
+
 ## 1.47.2
 
 - Restore `Send + Sync` on `Settings`, `Redactions`, and `Redaction` by

--- a/insta/src/redaction.rs
+++ b/insta/src/redaction.rs
@@ -388,7 +388,12 @@ impl<'a> Selector<'a> {
             let forward_sel = &selector[..idx];
             let backward_sel = &selector[idx + 1..];
 
-            if path.len() <= idx {
+            // `**` matches zero or more segments between the forward and
+            // backward parts, but the path must still be long enough to hold
+            // both ends without them overlapping. With no backward part `**`
+            // must consume at least one segment, so `.**` never matches the
+            // root and `.foo.**` never matches `foo` itself.
+            if path.len() < forward_sel.len() + backward_sel.len().max(1) {
                 return false;
             }
 
@@ -419,12 +424,29 @@ impl<'a> Selector<'a> {
     }
 
     pub fn is_match(&self, path: &[PathItem]) -> bool {
+        let (deep, shallow) = self.match_kind(path);
+        deep || shallow
+    }
+
+    /// Returns `(deep, shallow)`: whether `path` is matched by a selector that
+    /// contains a deep wildcard (`**`) and/or by an exact (non-deep) selector.
+    ///
+    /// The distinction drives recursion: an exact selector consumes the node it
+    /// matches, while a deep wildcard means "this node and everything below it",
+    /// so redaction keeps descending into the matched value.
+    fn match_kind(&self, path: &[PathItem]) -> (bool, bool) {
+        let mut deep = false;
+        let mut shallow = false;
         for selector in &self.selectors {
             if self.selector_is_match(selector, path) {
-                return true;
+                if selector.contains(&Segment::DeepWildcard) {
+                    deep = true;
+                } else {
+                    shallow = true;
+                }
             }
         }
-        false
+        (deep, shallow)
     }
 
     pub fn redact(&self, value: Content, redaction: &Redaction) -> Content {
@@ -471,64 +493,73 @@ impl<'a> Selector<'a> {
         redaction: &Redaction,
         path: &mut Vec<PathItem>,
     ) -> Content {
-        if self.is_match(path) {
+        let (deep_match, shallow_match) = self.match_kind(path);
+        let value = if deep_match || shallow_match {
             redaction.redact(value, path)
         } else {
-            match value {
-                Content::Map(map) => Content::Map(
-                    map.into_iter()
-                        .map(|(key, value)| {
-                            path.push(PathItem::Field("$key"));
-                            let new_key = self.redact_impl(key.clone(), redaction, path);
-                            path.pop();
+            value
+        };
 
-                            path.push(PathItem::Content(key));
-                            let new_value = self.redact_impl(value, redaction, path);
-                            path.pop();
+        // An exact selector consumes the node it matches: redact and stop. A
+        // deep wildcard means "this node and everything below it", so keep
+        // descending into the redacted value to reach nested matches,
+        // including through arrays, which a bare `.**` would otherwise stop at.
+        // A structure-preserving redaction (e.g. rounding) then visits the real
+        // descendants; one that replaces a container with a scalar simply finds
+        // nothing left to recurse into.
+        if shallow_match && !deep_match {
+            return value;
+        }
 
-                            (new_key, new_value)
-                        })
-                        .collect(),
-                ),
-                Content::Seq(seq) => Content::Seq(self.redact_seq(seq, redaction, path)),
-                Content::Tuple(seq) => Content::Tuple(self.redact_seq(seq, redaction, path)),
-                Content::TupleStruct(name, seq) => {
-                    Content::TupleStruct(name, self.redact_seq(seq, redaction, path))
-                }
-                Content::TupleVariant(name, variant_index, variant, seq) => Content::TupleVariant(
-                    name,
-                    variant_index,
-                    variant,
-                    self.redact_seq(seq, redaction, path),
-                ),
-                Content::Struct(name, seq) => {
-                    Content::Struct(name, self.redact_struct(seq, redaction, path))
-                }
-                Content::StructVariant(name, variant_index, variant, seq) => {
-                    Content::StructVariant(
-                        name,
-                        variant_index,
-                        variant,
-                        self.redact_struct(seq, redaction, path),
-                    )
-                }
-                Content::NewtypeStruct(name, inner) => Content::NewtypeStruct(
-                    name,
-                    Box::new(self.redact_impl(*inner, redaction, path)),
-                ),
-                Content::NewtypeVariant(name, index, variant_name, inner) => {
-                    Content::NewtypeVariant(
-                        name,
-                        index,
-                        variant_name,
-                        Box::new(self.redact_impl(*inner, redaction, path)),
-                    )
-                }
-                Content::Some(contents) => {
-                    Content::Some(Box::new(self.redact_impl(*contents, redaction, path)))
-                }
-                other => other,
+        match value {
+            Content::Map(map) => Content::Map(
+                map.into_iter()
+                    .map(|(key, value)| {
+                        path.push(PathItem::Field("$key"));
+                        let new_key = self.redact_impl(key.clone(), redaction, path);
+                        path.pop();
+
+                        path.push(PathItem::Content(key));
+                        let new_value = self.redact_impl(value, redaction, path);
+                        path.pop();
+
+                        (new_key, new_value)
+                    })
+                    .collect(),
+            ),
+            Content::Seq(seq) => Content::Seq(self.redact_seq(seq, redaction, path)),
+            Content::Tuple(seq) => Content::Tuple(self.redact_seq(seq, redaction, path)),
+            Content::TupleStruct(name, seq) => {
+                Content::TupleStruct(name, self.redact_seq(seq, redaction, path))
             }
+            Content::TupleVariant(name, variant_index, variant, seq) => Content::TupleVariant(
+                name,
+                variant_index,
+                variant,
+                self.redact_seq(seq, redaction, path),
+            ),
+            Content::Struct(name, seq) => {
+                Content::Struct(name, self.redact_struct(seq, redaction, path))
+            }
+            Content::StructVariant(name, variant_index, variant, seq) => Content::StructVariant(
+                name,
+                variant_index,
+                variant,
+                self.redact_struct(seq, redaction, path),
+            ),
+            Content::NewtypeStruct(name, inner) => {
+                Content::NewtypeStruct(name, Box::new(self.redact_impl(*inner, redaction, path)))
+            }
+            Content::NewtypeVariant(name, index, variant_name, inner) => Content::NewtypeVariant(
+                name,
+                index,
+                variant_name,
+                Box::new(self.redact_impl(*inner, redaction, path)),
+            ),
+            Content::Some(contents) => {
+                Content::Some(Box::new(self.redact_impl(*contents, redaction, path)))
+            }
+            other => other,
         }
     }
 }

--- a/insta/tests/test_redaction.rs
+++ b/insta/tests/test_redaction.rs
@@ -401,9 +401,8 @@ fn test_redact_recursive() {
 #[test]
 fn test_redact_recursive_array() {
     // A deep wildcard recurses through arrays, not just nested structs: `.**.data`
-    // matches every `data` field at any depth inside the `nodes` vectors. A bare
-    // `.**` would instead match each `nodes` array itself and stop descending, so
-    // only the root would be redacted. See https://github.com/mitsuhiko/insta/issues/687.
+    // matches every `data` field at any depth inside the `nodes` vectors.
+    // See https://github.com/mitsuhiko/insta/issues/687.
     #[derive(Serialize)]
     pub struct Node {
         data: f64,
@@ -447,6 +446,89 @@ fn test_redact_recursive_array() {
           "nodes": []
         }
       ]
+    }
+    "#);
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn test_redact_deep_wildcard_into_arrays() {
+    // A bare `.**` applies the redaction to every node at every depth, recursing
+    // through arrays. The redaction is a no-op on the `nodes` arrays and structs
+    // but rounds every `data` leaf, without needing to name the field.
+    // See https://github.com/mitsuhiko/insta/issues/687.
+    #[derive(Serialize)]
+    pub struct Node {
+        data: f64,
+        nodes: Vec<Node>,
+    }
+
+    let root = Node {
+        data: 1.111_111,
+        nodes: vec![
+            Node {
+                data: 2.222_222,
+                nodes: vec![Node {
+                    data: 3.333_333,
+                    nodes: vec![],
+                }],
+            },
+            Node {
+                data: 4.444_444,
+                nodes: vec![],
+            },
+        ],
+    };
+
+    assert_json_snapshot!(root, {
+        ".**" => insta::rounded_redaction(2),
+    }, @r#"
+    {
+      "data": 1.11,
+      "nodes": [
+        {
+          "data": 2.22,
+          "nodes": [
+            {
+              "data": 3.33,
+              "nodes": []
+            }
+          ]
+        },
+        {
+          "data": 4.44,
+          "nodes": []
+        }
+      ]
+    }
+    "#);
+}
+
+#[cfg(feature = "json")]
+#[test]
+fn test_redact_deep_wildcard_suffix_length() {
+    // The segments after `**` are matched against the end of the path, so a
+    // path must be at least as long as that suffix to match. `.**.a.b` must
+    // therefore only match a value reached via `.a.b`, never a top-level `b`.
+    #[derive(Serialize)]
+    struct Inner {
+        b: u32,
+    }
+
+    #[derive(Serialize)]
+    struct Root {
+        b: u32,
+        a: Inner,
+    }
+
+    assert_json_snapshot!(Root { b: 1, a: Inner { b: 2 } }, {
+        ".**.a.b" => "[redacted]",
+    }, @r#"
+    {
+      "b": 1,
+      "a": {
+        "b": "[redacted]"
+      }
     }
     "#);
 }


### PR DESCRIPTION
**Draft / proposal — this is a breaking change, opened so #687's reporter and others can test it.**

Makes a bare `.**` (and any `**` selector that matches a collection) recurse into every descendant instead of stopping at the first matched collection. `.** => rounded_redaction(n)` now rounds every float in a recursive structure, including inside arrays, without naming fields.

## What changes

When `.**` matched a container, the old behavior redacted that node and stopped, so `.** => rounded_redaction(3)` rounded only the top level. Now a deep-wildcard match redacts the node and keeps descending, so it applies to every node in the subtree. This is what JSONPath `..` and jq `..` do. Exact (non-`**`) selectors are unchanged: they still consume the node they match and stop.

It also tightens the suffix-length guard so `**` selectors with two or more trailing segments (`.**[].*`, `.**.a.b`) no longer match paths too short to contain them.

## Compatibility (why this is a draft)

Output changes only for selectors containing `**`. Exact-selector redactions are byte-for-byte identical. For `**` paired with a structure-preserving redaction, the redaction now runs on more nodes:

- `.** => static` — unchanged (the container is replaced by a scalar; nothing to recurse into).
- `.** => sorted_redaction()` — now sorts nested collections too.
- `.** => dynamic_redaction(...)` — the closure runs on nested nodes, array elements, and map keys.

Real snapshots that would change, found via GitHub code search:

- **lumen-oss/lux** — `.** => sorted_redaction()`: [`lux-lib/src/lockfile/mod.rs#L1385`](https://github.com/lumen-oss/lux/blob/6806368524238fdab2f1d1fa93302e0ba4a5463c/lux-lib/src/lockfile/mod.rs#L1385) and [`#L1438`](https://github.com/lumen-oss/lux/blob/6806368524238fdab2f1d1fa93302e0ba4a5463c/lux-lib/src/lockfile/mod.rs#L1438)
- **blainehansen/postgres-static-analyzer** — `.** => sorted_redaction()`: [`reflect/src/reflect_test.rs#L14`](https://github.com/blainehansen/postgres-static-analyzer/blob/4b75114b2b692dce741b1e8b64b4824787ec81f4/reflect/src/reflect_test.rs#L14)
- **prisma/prisma-engines** — `.*[].** => redact_id()` (a `dynamic_redaction`), across ~13 telemetry tests: [`libs/telemetry/src/layer.rs#L430`](https://github.com/prisma/prisma-engines/blob/3c6e192761c0362d496ed980de936e2f3cebcd3a/libs/telemetry/src/layer.rs#L430)

In every case the new behavior matches the author's apparent intent (sort everything, redact every id), but their committed snapshots would need re-accepting.

## Alternative

If the churn isn't worth it, #917 is the conservative path: it ships only the guard fix and leaves `.**` semantics alone, with `.**.<field>` as the documented way to reach nested leaves. This PR supersedes #917; if this lands, #917 can close.

Closes #687.

> _This was written by Claude Code on behalf of max_
