### PR TITLE
Allow `CI=true` to be overridden by an explicitly passed `--accept` CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to insta and cargo-insta are documented here.
 
 ## Unreleased
 
+- Setting `CI=true` normally makes `cargo insta test` behave as though `--check`
+  was passed. Explicit snapshot handling options such as `--accept` now take
+  precedence over this environment variable, allowing users to override this
+  behavior if they want to.
 - Fix `cargo insta test --profile` being forwarded to nextest as the nextest
   profile instead of the cargo build profile; it now translates to
   `--cargo-profile` for the nextest runner. Add `--nextest-profile` to select

--- a/cargo-insta/src/cli.rs
+++ b/cargo-insta/src/cli.rs
@@ -910,7 +910,13 @@ fn test_run(mut cmd: TestCommand, color: ColorWhen) -> Result<(), Box<dyn Error>
     // is `SnapshotUpdate::Auto`.
     match loc.tool_config.snapshot_update() {
         SnapshotUpdate::Auto => {
-            if is_ci() {
+            // CI check mode is only a default; explicit snapshot handling flags take precedence.
+            if is_ci()
+                && !cmd.accept
+                && !cmd.accept_unseen
+                && !cmd.review
+                && !cmd.force_update_snapshots
+            {
                 cmd.check = true;
             }
         }

--- a/cargo-insta/tests/functional/main.rs
+++ b/cargo-insta/tests/functional/main.rs
@@ -312,6 +312,107 @@ impl TestProject {
 }
 
 #[test]
+fn test_accept_overrides_ci_check_mode() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("accept-overrides-ci-check-mode")
+        .add_file(
+            "src/lib.rs",
+            r#"#[test]
+fn test_snapshot() {
+    insta::assert_snapshot!("new value", @"old value");
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    let output = test_project
+        .insta_cmd()
+        .env("CI", "true")
+        .args(["test", "--accept"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "cargo insta test --accept failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_snapshot!(test_project.diff("src/lib.rs"), @r#"
+    --- Original: src/lib.rs
+    +++ Updated: src/lib.rs
+    @@ -1,4 +1,4 @@
+     #[test]
+     fn test_snapshot() {
+    -    insta::assert_snapshot!("new value", @"old value");
+    +    insta::assert_snapshot!("new value", @"new value");
+     }
+    "#);
+}
+
+#[test]
+fn test_snapshot_handling_options_override_ci_check_mode() {
+    let test_project = TestFiles::new()
+        .add_cargo_toml("snapshot-handling-options-override-ci-check-mode")
+        .add_file(
+            "src/lib.rs",
+            r#"#[test]
+fn test_snapshot_update_environment() {
+    assert_eq!(
+        std::env::var("INSTA_UPDATE").unwrap(),
+        std::env::var("EXPECTED_INSTA_UPDATE").unwrap(),
+    );
+    assert_eq!(
+        std::env::var("INSTA_FORCE_PASS").unwrap_or_default(),
+        std::env::var("EXPECTED_INSTA_FORCE_PASS").unwrap(),
+    );
+}
+"#
+            .to_string(),
+        )
+        .create_project();
+
+    for (name, args, expected_update, expected_force_pass) in [
+        ("CI default", &["test"][..], "no", ""),
+        ("--accept", &["test", "--accept"][..], "new", "1"),
+        (
+            "--accept-unseen",
+            &["test", "--accept-unseen"][..],
+            "unseen",
+            "1",
+        ),
+        ("--review", &["test", "--review"][..], "new", "1"),
+        (
+            "--force-update-snapshots",
+            &["test", "--force-update-snapshots"][..],
+            "force",
+            "1",
+        ),
+    ] {
+        let output = test_project
+            .insta_cmd()
+            .env("CI", "true")
+            .env("EXPECTED_INSTA_UPDATE", expected_update)
+            .env("EXPECTED_INSTA_FORCE_PASS", expected_force_pass)
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .unwrap();
+
+        assert!(
+            output.status.success(),
+            "{name} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+}
+
+#[test]
 fn test_force_update_snapshots() {
     fn create_test_force_update_project(name: &str, insta_dependency: &str) -> TestProject {
         TestFiles::new()


### PR DESCRIPTION
We have a CI job over at Ruff that automatically creates a PR updating some vendored files every two weeks. Updating the vendored files often means that snapshots need to be updated, and I'd like that to be done as part of the automated workflow using `--accept`. However, currently if the `CI` environment variable is set to a truthy value (which it always is in the context of GitHub Actions), that cannot be overridden using `--accept`.

That seems like an oversight in https://github.com/mitsuhiko/insta/pull/345: normally, CLI flags take precedence over environment variables. This PR fixes that oversight