### PR TITLE
Release 1.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,28 @@
 
 All notable changes to insta and cargo-insta are documented here.
 
-## Unreleased
+## 1.48.0
 
+- Add `strip_ansi_escape_codes` setting which removes ANSI escape sequences
+  (color codes, cursor movement, etc.) from snapshot content before comparison.
+  Requires the `filters` feature. #899 (@pierluigilenoci)
+- Add opt-in support for YAML literal blocks for multiline strings in snapshot
+  metadata fields such as `description` and `expression`. Set
+  `INSTA_YAML_BLOCK_STYLE=1` to enable. #851 (@ivov)
 - Setting `CI=true` normally makes `cargo insta test` behave as though `--check`
   was passed. Explicit snapshot handling options such as `--accept` now take
   precedence over this environment variable, allowing users to override this
-  behavior if they want to.
+  behavior if they want to. #924
 - Fix `cargo insta test --profile` being forwarded to nextest as the nextest
   profile instead of the cargo build profile; it now translates to
   `--cargo-profile` for the nextest runner. Add `--nextest-profile` to select
   the nextest profile. #910
+- Fix `cargo insta pending-snapshots` printing unusable `\\?\`-prefixed paths
+  on Windows. The `--snapshot` filter now also accepts partial paths: any
+  trailing path suffix of the snapshot file matches, so a bare
+  `--snapshot my_test.snap` works. #904
+- Accepting a binary snapshot no longer fails with `os error 2` when its data
+  file is missing (e.g. gitignored and not committed). #914
 
 ## 1.47.2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-insta"
-version = "1.47.2"
+version = "1.48.0"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 dependencies = [
  "clap",
  "console 0.16.0",

--- a/cargo-insta/Cargo.toml
+++ b/cargo-insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-insta"
-version = "1.47.2"
+version = "1.48.0"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A review tool for the insta snapshot testing library for Rust"
@@ -14,7 +14,7 @@ readme = "README.md"
 rust-version = "1.66.0"
 
 [dependencies]
-insta = { version = "=1.47.2", path = "../insta", features = [
+insta = { version = "=1.48.0", path = "../insta", features = [
     "json",
     "yaml",
     "redactions",

--- a/insta/Cargo.toml
+++ b/insta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 license = "Apache-2.0"
 authors = ["Armin Ronacher <armin.ronacher@active-4.com>"]
 description = "A snapshot testing library for Rust"


### PR DESCRIPTION
Minor release. Highlights since 1.47.2:

- `strip_ansi_escape_codes` setting (#899, @pierluigilenoci)
- Opt-in YAML literal blocks for multiline metadata strings via `INSTA_YAML_BLOCK_STYLE=1` (#851, @ivov)
- An explicit `--accept` now overrides `CI=true` (#924)
- `cargo insta test --profile` now translates to nextest's `--cargo-profile`; new `--nextest-profile` flag (#910)
- Windows `--snapshot` path fix and partial-path filter matching (#904)
- Accepting a binary snapshot tolerates a missing data file (#914)

> _This was written by Claude Code on behalf of @max-sixty_
