### PR TITLE
[fix] Mention INSTA_UPDATE variable in snapshot mismatch errors

### DIFF
--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -125,7 +125,10 @@ pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &s
         if top.show_insta_hint {
             println!(
                 "{hint}",
-                hint = style("To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`").dim(),
+                hint = style(
+                    "To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`"
+                )
+                .dim(),
             );
         }
         if top.failed > 1 {

--- a/insta/src/glob.rs
+++ b/insta/src/glob.rs
@@ -125,7 +125,7 @@ pub fn glob_exec<F: FnMut(&Path)>(workspace_dir: &Path, base: &Path, pattern: &s
         if top.show_insta_hint {
             println!(
                 "{hint}",
-                hint = style("To update snapshots run `cargo insta review`").dim(),
+                hint = style("To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`").dim(),
             );
         }
         if top.failed > 1 {

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -678,7 +678,10 @@ impl<'a> SnapshotAssertionContext<'a> {
         {
             println!(
                 "{hint}",
-                hint = style("To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`").dim(),
+                hint = style(
+                    "To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`"
+                )
+                .dim(),
             );
         }
 

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -678,7 +678,7 @@ impl<'a> SnapshotAssertionContext<'a> {
         {
             println!(
                 "{hint}",
-                hint = style("To update snapshots run `cargo insta review`").dim(),
+                hint = style("To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`").dim(),
             );
         }
 

--- a/insta/src/runtime.rs
+++ b/insta/src/runtime.rs
@@ -676,13 +676,14 @@ impl<'a> SnapshotAssertionContext<'a> {
             && self.tool_config.output_behavior() != OutputBehavior::Nothing
             && !self.is_doctest
         {
-            println!(
-                "{hint}",
-                hint = style(
-                    "To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`"
-                )
-                .dim(),
-            );
+            // `INSTA_UPDATE=always` only bypasses review for file snapshots;
+            // inline snapshots always go through a pending file.
+            let hint = if self.snapshot_file.is_some() {
+                "To update snapshots run `cargo insta review` or set `INSTA_UPDATE=always`"
+            } else {
+                "To update snapshots run `cargo insta review`"
+            };
+            println!("{hint}", hint = style(hint).dim());
         }
 
         if update_result != SnapshotUpdateBehavior::InPlace && !self.tool_config.force_pass() {
@@ -705,6 +706,7 @@ impl<'a> SnapshotAssertionContext<'a> {
                     glob_collector.failed += 1;
                     if update_result == SnapshotUpdateBehavior::NewFile
                         && self.tool_config.output_behavior() != OutputBehavior::Nothing
+                        && self.snapshot_file.is_some()
                     {
                         glob_collector.show_insta_hint = true;
                     }


### PR DESCRIPTION
The snapshot mismatch error message now mentions the `INSTA_UPDATE=always` environment variable as an alternative to `cargo insta review`, helping users who do not use cargo-insta discover this option.

Closes #926